### PR TITLE
Fixing configuration saving priorities

### DIFF
--- a/src/file_sharing/p3filelists.cc
+++ b/src/file_sharing/p3filelists.cc
@@ -91,7 +91,7 @@ void p3FileDatabase::setIgnoreLists(const std::list<std::string>& ignored_prefix
     RS_STACK_MUTEX(mFLSMtx) ;
     mLocalDirWatcher->setIgnoreLists(ignored_prefixes,ignored_suffixes,ignore_flags) ;
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 }
 bool p3FileDatabase::getIgnoreLists(std::list<std::string>& ignored_prefixes,std::list<std::string>& ignored_suffixes, uint32_t& ignore_flags)
 {
@@ -120,7 +120,7 @@ void p3FileDatabase::setSharedDirectories(const std::list<SharedDirInfo>& shared
 
     }
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 }
 void p3FileDatabase::getSharedDirectories(std::list<SharedDirInfo>& shared_dirs)
 {
@@ -135,7 +135,7 @@ void p3FileDatabase::updateShareFlags(const SharedDirInfo& info)
     }
 
     RsServer::notify()->notifyListChange(NOTIFY_LIST_DIRLIST_LOCAL, 0);
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 }
 
 p3FileDatabase::~p3FileDatabase()
@@ -207,7 +207,7 @@ int p3FileDatabase::tick()
 
     if(mUpdateFlags)
     {
-        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 
         if(mUpdateFlags & P3FILELISTS_UPDATE_FLAG_LOCAL_DIRS_CHANGED)
             RsServer::notify()->notifyListChange(NOTIFY_LIST_DIRLIST_LOCAL, 0);
@@ -704,7 +704,7 @@ void p3FileDatabase::cleanup()
 			std::cerr << "(WW) Initialising directory watcher salt to some random value " << std::endl;
 			mLocalDirWatcher->setHashSalt(RsFileHash::random()) ;
 
-            IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
+            IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);
 		}
     }
 }
@@ -755,7 +755,7 @@ uint32_t p3FileDatabase::locked_getFriendIndex(const RsPeerId& pid)
 
         mFriendIndexMap[pid] = found;
 
-        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 
         return found ;
     }
@@ -1268,7 +1268,7 @@ void p3FileDatabase::setFollowSymLinks(bool b)
 {
     RS_STACK_MUTEX(mFLSMtx) ;
     mLocalDirWatcher->setFollowSymLinks(b) ;
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 }
 bool p3FileDatabase::followSymLinks() const
 {
@@ -1279,7 +1279,7 @@ void p3FileDatabase::setIgnoreDuplicates(bool i)
 {
     RS_STACK_MUTEX(mFLSMtx) ;
     mLocalDirWatcher->setIgnoreDuplicates(i) ;
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 }
 bool p3FileDatabase::ignoreDuplicates() const
 {
@@ -1290,7 +1290,7 @@ void p3FileDatabase::setMaxShareDepth(int i)
 {
     RS_STACK_MUTEX(mFLSMtx) ;
     mLocalDirWatcher->setMaxShareDepth(i) ;
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 }
 int  p3FileDatabase::maxShareDepth() const
 {
@@ -1301,7 +1301,7 @@ void p3FileDatabase::setWatchEnabled(bool b)
 {
     RS_STACK_MUTEX(mFLSMtx) ;
     mLocalDirWatcher->setEnabled(b) ;
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 }
 bool p3FileDatabase::watchEnabled()
 {
@@ -1313,7 +1313,7 @@ void p3FileDatabase::setWatchPeriod(uint32_t seconds)
     RS_STACK_MUTEX(mFLSMtx) ;
 
     mLocalDirWatcher->setFileWatchPeriod(seconds);
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 }
 uint32_t p3FileDatabase::watchPeriod()
 {
@@ -2100,7 +2100,7 @@ bool p3FileDatabase::banFile(const RsFileHash& real_file_hash, const std::string
 		}
 	}
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);
 	return true;
 }
 bool p3FileDatabase::unbanFile(const RsFileHash& real_file_hash)
@@ -2115,7 +2115,7 @@ bool p3FileDatabase::unbanFile(const RsFileHash& real_file_hash)
         mBannedFileListNeedsUpdate = true ;
     }
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);
     return true;
 }
 
@@ -2156,7 +2156,7 @@ void p3FileDatabase::setTrustFriendNodesForBannedFiles(bool b)
 {
 	if(b != mTrustFriendNodesForBannedFiles)
     {
-        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
         mBannedFileListNeedsUpdate = true;
     }
 

--- a/src/file_sharing/p3filelists.cc
+++ b/src/file_sharing/p3filelists.cc
@@ -91,7 +91,7 @@ void p3FileDatabase::setIgnoreLists(const std::list<std::string>& ignored_prefix
     RS_STACK_MUTEX(mFLSMtx) ;
     mLocalDirWatcher->setIgnoreLists(ignored_prefixes,ignored_suffixes,ignore_flags) ;
 
-    IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 }
 bool p3FileDatabase::getIgnoreLists(std::list<std::string>& ignored_prefixes,std::list<std::string>& ignored_suffixes, uint32_t& ignore_flags)
 {
@@ -120,7 +120,7 @@ void p3FileDatabase::setSharedDirectories(const std::list<SharedDirInfo>& shared
 
     }
 
-    IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 }
 void p3FileDatabase::getSharedDirectories(std::list<SharedDirInfo>& shared_dirs)
 {
@@ -135,7 +135,7 @@ void p3FileDatabase::updateShareFlags(const SharedDirInfo& info)
     }
 
     RsServer::notify()->notifyListChange(NOTIFY_LIST_DIRLIST_LOCAL, 0);
-    IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 }
 
 p3FileDatabase::~p3FileDatabase()
@@ -207,7 +207,7 @@ int p3FileDatabase::tick()
 
     if(mUpdateFlags)
     {
-        IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 
         if(mUpdateFlags & P3FILELISTS_UPDATE_FLAG_LOCAL_DIRS_CHANGED)
             RsServer::notify()->notifyListChange(NOTIFY_LIST_DIRLIST_LOCAL, 0);
@@ -704,7 +704,7 @@ void p3FileDatabase::cleanup()
 			std::cerr << "(WW) Initialising directory watcher salt to some random value " << std::endl;
 			mLocalDirWatcher->setHashSalt(RsFileHash::random()) ;
 
-            IndicateConfigChanged();
+            IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
 		}
     }
 }
@@ -755,7 +755,7 @@ uint32_t p3FileDatabase::locked_getFriendIndex(const RsPeerId& pid)
 
         mFriendIndexMap[pid] = found;
 
-        IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 
         return found ;
     }
@@ -1268,7 +1268,7 @@ void p3FileDatabase::setFollowSymLinks(bool b)
 {
     RS_STACK_MUTEX(mFLSMtx) ;
     mLocalDirWatcher->setFollowSymLinks(b) ;
-    IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 }
 bool p3FileDatabase::followSymLinks() const
 {
@@ -1279,7 +1279,7 @@ void p3FileDatabase::setIgnoreDuplicates(bool i)
 {
     RS_STACK_MUTEX(mFLSMtx) ;
     mLocalDirWatcher->setIgnoreDuplicates(i) ;
-    IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 }
 bool p3FileDatabase::ignoreDuplicates() const
 {
@@ -1290,7 +1290,7 @@ void p3FileDatabase::setMaxShareDepth(int i)
 {
     RS_STACK_MUTEX(mFLSMtx) ;
     mLocalDirWatcher->setMaxShareDepth(i) ;
-    IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 }
 int  p3FileDatabase::maxShareDepth() const
 {
@@ -1301,7 +1301,7 @@ void p3FileDatabase::setWatchEnabled(bool b)
 {
     RS_STACK_MUTEX(mFLSMtx) ;
     mLocalDirWatcher->setEnabled(b) ;
-    IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 }
 bool p3FileDatabase::watchEnabled()
 {
@@ -1313,7 +1313,7 @@ void p3FileDatabase::setWatchPeriod(uint32_t seconds)
     RS_STACK_MUTEX(mFLSMtx) ;
 
     mLocalDirWatcher->setFileWatchPeriod(seconds);
-    IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 }
 uint32_t p3FileDatabase::watchPeriod()
 {
@@ -2100,7 +2100,7 @@ bool p3FileDatabase::banFile(const RsFileHash& real_file_hash, const std::string
 		}
 	}
 
-    IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
 	return true;
 }
 bool p3FileDatabase::unbanFile(const RsFileHash& real_file_hash)
@@ -2115,7 +2115,7 @@ bool p3FileDatabase::unbanFile(const RsFileHash& real_file_hash)
         mBannedFileListNeedsUpdate = true ;
     }
 
-    IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
     return true;
 }
 
@@ -2156,7 +2156,7 @@ void p3FileDatabase::setTrustFriendNodesForBannedFiles(bool b)
 {
 	if(b != mTrustFriendNodesForBannedFiles)
     {
-		IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
         mBannedFileListNeedsUpdate = true;
     }
 

--- a/src/ft/ftcontroller.cc
+++ b/src/ft/ftcontroller.cc
@@ -229,7 +229,7 @@ void ftController::threadTick()
 		rstime_t now = time(NULL) ;
 		if(now > last_save_time + SAVE_TRANSFERS_DELAY)
 		{
-			IndicateConfigChanged() ;
+            IndicateConfigChanged(RsConfigMgr::SAVE_NOW) ;	// normally SAVE_OFTEN, but we're already using a delay system.
 			last_save_time = now ;
 		}
 
@@ -823,7 +823,7 @@ bool ftController::completeFile(const RsFileHash& hash)
 
     rsFiles->ForceDirectoryCheck(true) ;
 
-	IndicateConfigChanged(); /* completed transfer -> save */
+    IndicateConfigChanged(RsConfigMgr::SAVE_NOW); /* completed transfer -> save */
 	return true;
 }
 
@@ -1224,7 +1224,7 @@ bool ftController::FileRequest(
 		mDownloads[hash] = ftfc;
 	}
 
-	IndicateConfigChanged(); /* completed transfer -> save */
+    IndicateConfigChanged(RsConfigMgr::SAVE_NOW); /* completed transfer -> save */
 	return true;
 }
 
@@ -1354,7 +1354,7 @@ bool 	ftController::FileCancel(const RsFileHash& hash)
 		mDownloads.erase(mit);
 	}
 
-	IndicateConfigChanged(); /* completed transfer -> save */
+    IndicateConfigChanged(RsConfigMgr::SAVE_NOW); /* completed transfer -> save */
 	return true;
 }
 
@@ -1397,7 +1397,7 @@ bool 	ftController::FileControl(const RsFileHash& hash, uint32_t flags)
 		default:
 			return false;
 	}
-	IndicateConfigChanged() ;
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN) ;
 
 	return true;
 }
@@ -1415,7 +1415,7 @@ bool ftController::FileClearCompleted()
 
 		mCompleted.clear();
 
-		IndicateConfigChanged();
+        IndicateConfigChanged();	// if we restart, completed transfers are lost, so no need to urgently save anything.
 	}
 
     if(rsEvents)
@@ -1518,7 +1518,7 @@ bool 	ftController::setPartialsDirectory(std::string path)
 			(it->second).mCreator->changePartialDirectory(mPartialPath);
 		}
 #endif
-        IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 		return true;
 	}
 
@@ -2212,7 +2212,7 @@ void ftController::setMaxUploadsPerFriend(uint32_t m)
 {
 	RsStackMutex stack(ctrlMutex); /******* LOCKED ********/
 	_max_uploads_per_friend = m ;
-	IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 }
 uint32_t ftController::getMaxUploadsPerFriend()
 {
@@ -2223,7 +2223,7 @@ void ftController::setDefaultEncryptionPolicy(uint32_t p)
 {
     RsStackMutex stack(ctrlMutex); /******* LOCKED ********/
     mDefaultEncryptionPolicy = p ;
-    IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 }
 uint32_t ftController::defaultEncryptionPolicy()
 {
@@ -2237,7 +2237,7 @@ void ftController::setFilePermDirectDL(uint32_t perm)
 	if (mFilePermDirectDLPolicy != perm)
 	{
 		mFilePermDirectDLPolicy = perm;
-		IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 	}
 }
 uint32_t ftController::filePermDirectDL()
@@ -2250,7 +2250,7 @@ void ftController::setFreeDiskSpaceLimit(uint32_t size_in_mb)
 {
 	RsDiscSpace::setFreeSpaceLimit(size_in_mb) ;
 
-	IndicateConfigChanged() ;
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN) ;
 }
 
 
@@ -2271,5 +2271,5 @@ void ftController::setDefaultChunkStrategy(FileChunksInfo::ChunkStrategy S)
 	std::cerr << "Note: in frController: setting chunk strategy to " << S << std::endl ;
 #endif
 	mDefaultChunkStrategy = S ;
-	IndicateConfigChanged() ;
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN) ;
 }

--- a/src/ft/ftcontroller.cc
+++ b/src/ft/ftcontroller.cc
@@ -229,7 +229,7 @@ void ftController::threadTick()
 		rstime_t now = time(NULL) ;
 		if(now > last_save_time + SAVE_TRANSFERS_DELAY)
 		{
-            IndicateConfigChanged(RsConfigMgr::SAVE_NOW) ;	// normally SAVE_OFTEN, but we're already using a delay system.
+            IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW) ;	// normally SAVE_OFTEN, but we're already using a delay system.
 			last_save_time = now ;
 		}
 
@@ -823,7 +823,7 @@ bool ftController::completeFile(const RsFileHash& hash)
 
     rsFiles->ForceDirectoryCheck(true) ;
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_NOW); /* completed transfer -> save */
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW); /* completed transfer -> save */
 	return true;
 }
 
@@ -1224,7 +1224,7 @@ bool ftController::FileRequest(
 		mDownloads[hash] = ftfc;
 	}
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_NOW); /* completed transfer -> save */
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW); /* completed transfer -> save */
 	return true;
 }
 
@@ -1354,7 +1354,7 @@ bool 	ftController::FileCancel(const RsFileHash& hash)
 		mDownloads.erase(mit);
 	}
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_NOW); /* completed transfer -> save */
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW); /* completed transfer -> save */
 	return true;
 }
 
@@ -1397,7 +1397,7 @@ bool 	ftController::FileControl(const RsFileHash& hash, uint32_t flags)
 		default:
 			return false;
 	}
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN) ;
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN) ;
 
 	return true;
 }
@@ -1518,7 +1518,7 @@ bool 	ftController::setPartialsDirectory(std::string path)
 			(it->second).mCreator->changePartialDirectory(mPartialPath);
 		}
 #endif
-        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 		return true;
 	}
 
@@ -2212,7 +2212,7 @@ void ftController::setMaxUploadsPerFriend(uint32_t m)
 {
 	RsStackMutex stack(ctrlMutex); /******* LOCKED ********/
 	_max_uploads_per_friend = m ;
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 }
 uint32_t ftController::getMaxUploadsPerFriend()
 {
@@ -2223,7 +2223,7 @@ void ftController::setDefaultEncryptionPolicy(uint32_t p)
 {
     RsStackMutex stack(ctrlMutex); /******* LOCKED ********/
     mDefaultEncryptionPolicy = p ;
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 }
 uint32_t ftController::defaultEncryptionPolicy()
 {
@@ -2237,7 +2237,7 @@ void ftController::setFilePermDirectDL(uint32_t perm)
 	if (mFilePermDirectDLPolicy != perm)
 	{
 		mFilePermDirectDLPolicy = perm;
-        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 	}
 }
 uint32_t ftController::filePermDirectDL()
@@ -2250,7 +2250,7 @@ void ftController::setFreeDiskSpaceLimit(uint32_t size_in_mb)
 {
 	RsDiscSpace::setFreeSpaceLimit(size_in_mb) ;
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN) ;
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN) ;
 }
 
 
@@ -2271,5 +2271,5 @@ void ftController::setDefaultChunkStrategy(FileChunksInfo::ChunkStrategy S)
 	std::cerr << "Note: in frController: setting chunk strategy to " << S << std::endl ;
 #endif
 	mDefaultChunkStrategy = S ;
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN) ;
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN) ;
 }

--- a/src/ft/ftextralist.cc
+++ b/src/ft/ftextralist.cc
@@ -109,7 +109,7 @@ void ftExtraList::hashAFile()
 		/* add to the path->hash map */
 		mHashedList[details.info.path] = details.info.hash;
 	
-        IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);
 
 		auto ev = std::make_shared<RsSharedDirectoriesEvent>();
 		ev->mEventCode = RsSharedDirectoriesEventCode::EXTRA_LIST_FILE_ADDED;
@@ -149,7 +149,7 @@ bool	ftExtraList::addExtraFile(std::string path, const RsFileHash& hash,
 	mFiles[details.info.hash] = details;
 	mHashOfHash[makeEncryptedHash(details.info.hash)] = details.info.hash ;
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);
 
 	return true;
 }
@@ -178,7 +178,7 @@ bool ftExtraList::removeExtraFile(const RsFileHash& hash)
 
 	mFiles.erase(it);
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);
 
     if(rsEvents)
     {
@@ -207,7 +207,7 @@ bool ftExtraList::moveExtraFile(std::string fname, const RsFileHash &hash, uint6
 		/* rename */
 		it->second.info.path = path;
 		it->second.info.fname = fname;
-        IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);
 	}
 
 	return true;
@@ -243,7 +243,7 @@ bool	ftExtraList::cleanupOldFiles()
 			mHashOfHash.erase(makeEncryptedHash(*rit));
         }
 
-        IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);
 	}
 	return true;
 }

--- a/src/ft/ftextralist.cc
+++ b/src/ft/ftextralist.cc
@@ -109,7 +109,7 @@ void ftExtraList::hashAFile()
 		/* add to the path->hash map */
 		mHashedList[details.info.path] = details.info.hash;
 	
-		IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
 
 		auto ev = std::make_shared<RsSharedDirectoriesEvent>();
 		ev->mEventCode = RsSharedDirectoriesEventCode::EXTRA_LIST_FILE_ADDED;
@@ -149,7 +149,7 @@ bool	ftExtraList::addExtraFile(std::string path, const RsFileHash& hash,
 	mFiles[details.info.hash] = details;
 	mHashOfHash[makeEncryptedHash(details.info.hash)] = details.info.hash ;
 
-	IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
 
 	return true;
 }
@@ -178,7 +178,7 @@ bool ftExtraList::removeExtraFile(const RsFileHash& hash)
 
 	mFiles.erase(it);
 
-	IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
 
     if(rsEvents)
     {
@@ -207,7 +207,7 @@ bool ftExtraList::moveExtraFile(std::string fname, const RsFileHash &hash, uint6
 		/* rename */
 		it->second.info.path = path;
 		it->second.info.fname = fname;
-		IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
 	}
 
 	return true;
@@ -243,7 +243,7 @@ bool	ftExtraList::cleanupOldFiles()
 			mHashOfHash.erase(makeEncryptedHash(*rit));
         }
 
-		IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
 	}
 	return true;
 }

--- a/src/pqi/p3cfgmgr.cc
+++ b/src/pqi/p3cfgmgr.cc
@@ -85,8 +85,6 @@ void p3ConfigMgr::saveConfig(CheckPriority t)
 			std::cerr << std::endl;
 #endif
 			ok &= (*it)->saveConfiguration();
-
-            RsDbg() << "Saving configuration file: " << (*it)->Filename() ;
 		}
 }
 

--- a/src/pqi/p3cfgmgr.cc
+++ b/src/pqi/p3cfgmgr.cc
@@ -66,7 +66,7 @@ void p3ConfigMgr::saveConfiguration()
 	if(!RsDiscSpace::checkForDiscSpace(RS_CONFIG_DIRECTORY))
 		return ;
 
-    saveConfig(SAVE_WHEN_CLOSING);
+    saveConfig(CheckPriority::SAVE_WHEN_CLOSING);
 }
 
 void p3ConfigMgr::saveConfig(CheckPriority t)
@@ -85,6 +85,8 @@ void p3ConfigMgr::saveConfig(CheckPriority t)
 			std::cerr << std::endl;
 #endif
 			ok &= (*it)->saveConfiguration();
+
+            RsDbg() << "Saving configuration file: " << (*it)->Filename() ;
 		}
 }
 
@@ -538,7 +540,7 @@ bool    p3GeneralConfig::loadList(std::list<RsItem *>& load)
  */
 
 pqiConfig::pqiConfig()
-    : cfgMtx("pqiConfig"), ConfInd(uint16_t(RsConfigMgr::SAVE_NOW))
+    : cfgMtx("pqiConfig")
 {
 }
 
@@ -561,13 +563,13 @@ const RsFileHash& pqiConfig::Hash()
 void	pqiConfig::IndicateConfigChanged(RsConfigMgr::CheckPriority t)
 {
 	RsStackMutex stack(cfgMtx); /***** LOCK STACK MUTEX ****/
-    ConfInd.IndicateChanged(t);
+    ConfInd.IndicateChanged(uint8_t(t));
 }
 
 bool	pqiConfig::HasConfigChanged(RsConfigMgr::CheckPriority t)
 {
 	RsStackMutex stack(cfgMtx); /***** LOCK STACK MUTEX ****/
-    return  ConfInd.Changed(uint16_t(t));
+    return  ConfInd.Changed(uint8_t(t));
 }
 bool	pqiConfig::resetChanges()
 {

--- a/src/pqi/p3cfgmgr.h
+++ b/src/pqi/p3cfgmgr.h
@@ -106,7 +106,8 @@ protected:
 
     /**
      * Sets configuration flag to changed. Default is to only save on close. This choice is however pretty dangerous
-     * because it causes data to be loss in case of crash.
+     * because it causes data to be lost on crash. Some services (FT, Friends,etc) may use higher priority levels when
+     * config is updated.
      */
     virtual void	IndicateConfigChanged(RsConfigMgr::CheckPriority t = RsConfigMgr::CheckPriority::SAVE_WHEN_CLOSING);
 

--- a/src/pqi/p3cfgmgr.h
+++ b/src/pqi/p3cfgmgr.h
@@ -108,7 +108,7 @@ protected:
      * Sets configuration flag to changed. Default is to only save on close. This choice is however pretty dangerous
      * because it causes data to be loss in case of crash.
      */
-    virtual void	IndicateConfigChanged(RsConfigMgr::CheckPriority t = RsConfigMgr::SAVE_WHEN_CLOSING);
+    virtual void	IndicateConfigChanged(RsConfigMgr::CheckPriority t = RsConfigMgr::CheckPriority::SAVE_WHEN_CLOSING);
 
     void	setHash(const RsFileHash& h);
 

--- a/src/pqi/p3peermgr.cc
+++ b/src/pqi/p3peermgr.cc
@@ -220,7 +220,7 @@ bool p3PeerMgrIMPL::forceHiddenNode()
 
 	mNetMgr->setIPServersEnabled(false);
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 	return true;
 }
 
@@ -241,7 +241,7 @@ bool p3PeerMgrIMPL::setOwnNetworkMode(uint32_t netMode)
 		if (mOwnState.netMode != (netMode & RS_NET_MODE_ACTUAL))
 		{
 			mOwnState.netMode = (netMode & RS_NET_MODE_ACTUAL);
-            IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
+            IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 			changed = true;
 		}
 	}
@@ -271,7 +271,7 @@ bool p3PeerMgrIMPL::setOwnVisState(uint16_t vs_disc, uint16_t vs_dht)
 			mOwnState.vs_disc = vs_disc;
 			mOwnState.vs_dht = vs_dht;
 			changed = true;
-            IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
+            IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 		}
 	}
 
@@ -578,7 +578,7 @@ bool p3PeerMgrIMPL::setHiddenDomainPort(const RsPeerId &ssl_id, const std::strin
 		domain = domain.substr(pos);
 	}
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 	if (ssl_id == AuthSSL::getAuthSSL()->OwnId())
 	{
@@ -631,14 +631,14 @@ bool p3PeerMgrIMPL::setProxyServerAddress(const uint32_t type, const struct sock
 	case RS_HIDDEN_TYPE_I2P:
 		if (!sockaddr_storage_same(mProxyServerAddressI2P, proxy_addr))
 		{
-            IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
+            IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 			mProxyServerAddressI2P = proxy_addr;
 		}
 		break;
 	case RS_HIDDEN_TYPE_TOR:
 		if (!sockaddr_storage_same(mProxyServerAddressTor, proxy_addr))
 		{
-            IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
+            IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 			mProxyServerAddressTor = proxy_addr;
 		}
 		break;
@@ -661,7 +661,7 @@ bool p3PeerMgrIMPL::resetOwnExternalAddressList()
     mOwnState.ipAddrs.mLocal.mAddrs.clear() ;
     mOwnState.ipAddrs.mExt.mAddrs.clear() ;
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 
     return true ;
 }
@@ -909,7 +909,7 @@ bool p3PeerMgrIMPL::notifyPgpKeyReceived(const RsPgpId& pgp_id)
     }
 
     if(changed)
-        IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);
 
     return true;
 }
@@ -1042,7 +1042,7 @@ bool p3PeerMgrIMPL::addFriend(const RsPeerId& input_id, const RsPgpId& input_gpg
 
 		notifyLinkMgr = true;
 
-        IndicateConfigChanged(RsConfigMgr::SAVE_NOW); /**** INDICATE MSG CONFIG CHANGED! *****/
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW); /**** INDICATE MSG CONFIG CHANGED! *****/
 	}
 
 	if (notifyLinkMgr)
@@ -1161,7 +1161,7 @@ bool p3PeerMgrIMPL::addSslOnlyFriend( const RsPeerId& sslId, const RsPgpId& pgp_
 		mStatusChanged = true;
 	} // RS_STACK_MUTEX(mPeerMtx);
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);
 	mLinkMgr->addFriend(sslId, dt.vs_dht != RS_VS_DHT_OFF);
 
 	/* To update IP addresses is much more confortable to use locators, beside
@@ -1255,7 +1255,7 @@ bool p3PeerMgrIMPL::removeFriend(const RsPgpId &id)
 	ids.push_back(id) ;
     assignPeersToGroup(RsNodeGroupId(), ids, false);
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_NOW); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 #ifdef PEER_DEBUG
 	printPeerLists(std::cerr);
@@ -1329,7 +1329,7 @@ bool p3PeerMgrIMPL::removeFriend(const RsPeerId &id, bool removePgpId)
 
     assignPeersToGroup(RsNodeGroupId(), pgpid_toRemove, false);
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_NOW); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 #ifdef PEER_DEBUG
 	printPeerLists(std::cerr);
@@ -1517,7 +1517,7 @@ bool p3PeerMgrIMPL::UpdateOwnAddress( const sockaddr_storage& pLocalAddr,
         }
     }
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
     mLinkMgr->setLocalAddress(localAddr);
 
     return true;
@@ -1561,7 +1561,7 @@ bool p3PeerMgrIMPL::addPeerLocator(const RsPeerId &sslId, const RsUrl& locator)
 		std::cerr << __PRETTY_FUNCTION__ << " Added locator: "
 		          << locator.toString() << std::endl;
 #endif
-        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 	}
 	return changed;
 }
@@ -1584,7 +1584,7 @@ bool p3PeerMgrIMPL::setLocalAddress( const RsPeerId &id,
 
 		if (changed)
 		{
-            IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
+            IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 			mNetMgr->setLocalAddress(addr);
 			mLinkMgr->setLocalAddress(addr);
@@ -1616,7 +1616,7 @@ bool p3PeerMgrIMPL::setLocalAddress( const RsPeerId &id,
 	it->second.updateIpAddressList(ipAddressTimed);
 #endif
 
-    if (changed) IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+    if (changed) IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 	return changed;
 }
 
@@ -1676,7 +1676,7 @@ bool p3PeerMgrIMPL::setExtAddress( const RsPeerId &id,
 #endif
 
 	if (changed) {
-        IndicateConfigChanged(RsConfigMgr::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
 	}
 
 	return changed;
@@ -1693,7 +1693,7 @@ bool p3PeerMgrIMPL::setDynDNS(const RsPeerId &id, const std::string &dyndns)
 
         if (mOwnState.dyndns.compare(dyndns) != 0) {
             mOwnState.dyndns = dyndns;
-            IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
+            IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
             changed = true;
 
             if(rsEvents)
@@ -1722,7 +1722,7 @@ bool p3PeerMgrIMPL::setDynDNS(const RsPeerId &id, const std::string &dyndns)
     /* "it" points to peer */
     if (it->second.dyndns.compare(dyndns) != 0) {
         it->second.dyndns = dyndns;
-        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
         changed = true;
     }
 
@@ -1961,7 +1961,7 @@ bool    p3PeerMgrIMPL::updateAddressList(const RsPeerId& id, const pqiIpAddrSet 
 	std::cerr << std::endl;
 #endif
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 	return true;
 }
@@ -2005,7 +2005,7 @@ bool    p3PeerMgrIMPL::updateCurrentAddress(const RsPeerId& id, const pqiIpAddre
 	std::cerr << std::endl;
 #endif
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 	return true;
 }
@@ -2057,7 +2057,7 @@ bool    p3PeerMgrIMPL::setNetworkMode(const RsPeerId &id, uint32_t netMode)
 	if (it->second.netMode != netMode)
 	{
 		it->second.netMode = netMode;
-        IndicateConfigChanged(RsConfigMgr::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
 		changed = true;
 	}
 
@@ -2169,7 +2169,7 @@ bool    p3PeerMgrIMPL::setVisState(const RsPeerId &id, uint16_t vs_disc, uint16_
 	}
 
     if (changed)
-        IndicateConfigChanged(RsConfigMgr::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 	return changed;
 }
@@ -2416,7 +2416,7 @@ bool p3PeerMgrIMPL::setMaxRates(const RsPgpId& pid,uint32_t maxUp,uint32_t maxDn
         p.max_up_rate_kbs = maxUp ;
         p.max_dl_rate_kbs = maxDn ;
 
-        IndicateConfigChanged(RsConfigMgr::SAVE_LESS);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_LESS);
 
         return true ;
 }
@@ -2703,7 +2703,7 @@ bool  p3PeerMgrIMPL::loadList(std::list<RsItem *>& load)
                     group_pair.second.peerIds.erase(profileIdIt);
                     profileIdIt=tmp;
 
-                    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+                    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
                 }
         }
     }
@@ -2797,7 +2797,7 @@ bool p3PeerMgrIMPL::addGroup(RsGroupInfo &groupInfo)
 
 	RsServer::notify()->notifyListChange(NOTIFY_LIST_GROUPLIST, NOTIFY_TYPE_ADD);
 
-    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 
 	return true;
 }
@@ -2837,7 +2837,7 @@ bool p3PeerMgrIMPL::editGroup(const RsNodeGroupId& groupId, RsGroupInfo &groupIn
     {
 		RsServer::notify()->notifyListChange(NOTIFY_LIST_GROUPLIST, NOTIFY_TYPE_MOD);
 
-        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 	}
 
 	return changed;
@@ -2879,7 +2879,7 @@ bool p3PeerMgrIMPL::removeGroup(const RsNodeGroupId& groupId)
 	if (changed) {
 		RsServer::notify()->notifyListChange(NOTIFY_LIST_GROUPLIST, NOTIFY_TYPE_DEL);
 
-        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 	}
 
 	return changed;
@@ -2967,7 +2967,7 @@ bool p3PeerMgrIMPL::assignPeersToGroup(const RsNodeGroupId &groupId, const std::
 	if (changed) {
 		RsServer::notify()->notifyListChange(NOTIFY_LIST_GROUPLIST, NOTIFY_TYPE_MOD);
 
-        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 	}
 
 	return changed;
@@ -3021,7 +3021,7 @@ void p3PeerMgrIMPL::setServicePermissionFlags(const RsPgpId& pgp_id, const Servi
 		//
 
 		mFriendsPermissionFlags[pgp_id] = flags ;
-        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 }
 
 /**********************************************************************
@@ -3103,7 +3103,7 @@ bool p3PeerMgrIMPL::removeBannedIps()
     if(cleanIpList(mOwnState.ipAddrs.mLocal.mAddrs,mOwnState.id,mLinkMgr) )  changed = true ;
 
     if(changed)
-        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_OFTEN);
 
     return true ;
 }

--- a/src/pqi/p3peermgr.cc
+++ b/src/pqi/p3peermgr.cc
@@ -220,7 +220,7 @@ bool p3PeerMgrIMPL::forceHiddenNode()
 
 	mNetMgr->setIPServersEnabled(false);
 
-	IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 	return true;
 }
 
@@ -241,7 +241,7 @@ bool p3PeerMgrIMPL::setOwnNetworkMode(uint32_t netMode)
 		if (mOwnState.netMode != (netMode & RS_NET_MODE_ACTUAL))
 		{
 			mOwnState.netMode = (netMode & RS_NET_MODE_ACTUAL);
-			IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+            IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 			changed = true;
 		}
 	}
@@ -271,7 +271,7 @@ bool p3PeerMgrIMPL::setOwnVisState(uint16_t vs_disc, uint16_t vs_dht)
 			mOwnState.vs_disc = vs_disc;
 			mOwnState.vs_dht = vs_dht;
 			changed = true;
-			IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+            IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 		}
 	}
 
@@ -578,7 +578,7 @@ bool p3PeerMgrIMPL::setHiddenDomainPort(const RsPeerId &ssl_id, const std::strin
 		domain = domain.substr(pos);
 	}
 
-	IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 	if (ssl_id == AuthSSL::getAuthSSL()->OwnId())
 	{
@@ -631,14 +631,14 @@ bool p3PeerMgrIMPL::setProxyServerAddress(const uint32_t type, const struct sock
 	case RS_HIDDEN_TYPE_I2P:
 		if (!sockaddr_storage_same(mProxyServerAddressI2P, proxy_addr))
 		{
-			IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+            IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 			mProxyServerAddressI2P = proxy_addr;
 		}
 		break;
 	case RS_HIDDEN_TYPE_TOR:
 		if (!sockaddr_storage_same(mProxyServerAddressTor, proxy_addr))
 		{
-			IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+            IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 			mProxyServerAddressTor = proxy_addr;
 		}
 		break;
@@ -661,7 +661,7 @@ bool p3PeerMgrIMPL::resetOwnExternalAddressList()
     mOwnState.ipAddrs.mLocal.mAddrs.clear() ;
     mOwnState.ipAddrs.mExt.mAddrs.clear() ;
 
-    IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 
     return true ;
 }
@@ -909,7 +909,7 @@ bool p3PeerMgrIMPL::notifyPgpKeyReceived(const RsPgpId& pgp_id)
     }
 
     if(changed)
-        IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
 
     return true;
 }
@@ -1042,7 +1042,7 @@ bool p3PeerMgrIMPL::addFriend(const RsPeerId& input_id, const RsPgpId& input_gpg
 
 		notifyLinkMgr = true;
 
-		IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+        IndicateConfigChanged(RsConfigMgr::SAVE_NOW); /**** INDICATE MSG CONFIG CHANGED! *****/
 	}
 
 	if (notifyLinkMgr)
@@ -1161,7 +1161,7 @@ bool p3PeerMgrIMPL::addSslOnlyFriend( const RsPeerId& sslId, const RsPgpId& pgp_
 		mStatusChanged = true;
 	} // RS_STACK_MUTEX(mPeerMtx);
 
-	IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_NOW);
 	mLinkMgr->addFriend(sslId, dt.vs_dht != RS_VS_DHT_OFF);
 
 	/* To update IP addresses is much more confortable to use locators, beside
@@ -1255,7 +1255,7 @@ bool p3PeerMgrIMPL::removeFriend(const RsPgpId &id)
 	ids.push_back(id) ;
     assignPeersToGroup(RsNodeGroupId(), ids, false);
 
-	IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::SAVE_NOW); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 #ifdef PEER_DEBUG
 	printPeerLists(std::cerr);
@@ -1329,7 +1329,7 @@ bool p3PeerMgrIMPL::removeFriend(const RsPeerId &id, bool removePgpId)
 
     assignPeersToGroup(RsNodeGroupId(), pgpid_toRemove, false);
 
-	IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::SAVE_NOW); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 #ifdef PEER_DEBUG
 	printPeerLists(std::cerr);
@@ -1517,7 +1517,7 @@ bool p3PeerMgrIMPL::UpdateOwnAddress( const sockaddr_storage& pLocalAddr,
         }
     }
 
-    IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
     mLinkMgr->setLocalAddress(localAddr);
 
     return true;
@@ -1561,7 +1561,7 @@ bool p3PeerMgrIMPL::addPeerLocator(const RsPeerId &sslId, const RsUrl& locator)
 		std::cerr << __PRETTY_FUNCTION__ << " Added locator: "
 		          << locator.toString() << std::endl;
 #endif
-		IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 	}
 	return changed;
 }
@@ -1584,7 +1584,7 @@ bool p3PeerMgrIMPL::setLocalAddress( const RsPeerId &id,
 
 		if (changed)
 		{
-			IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+            IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 			mNetMgr->setLocalAddress(addr);
 			mLinkMgr->setLocalAddress(addr);
@@ -1616,7 +1616,7 @@ bool p3PeerMgrIMPL::setLocalAddress( const RsPeerId &id,
 	it->second.updateIpAddressList(ipAddressTimed);
 #endif
 
-	if (changed) IndicateConfigChanged();
+    if (changed) IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 	return changed;
 }
 
@@ -1676,7 +1676,7 @@ bool p3PeerMgrIMPL::setExtAddress( const RsPeerId &id,
 #endif
 
 	if (changed) {
-		IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+        IndicateConfigChanged(RsConfigMgr::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
 	}
 
 	return changed;
@@ -1693,7 +1693,7 @@ bool p3PeerMgrIMPL::setDynDNS(const RsPeerId &id, const std::string &dyndns)
 
         if (mOwnState.dyndns.compare(dyndns) != 0) {
             mOwnState.dyndns = dyndns;
-            IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+            IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
             changed = true;
 
             if(rsEvents)
@@ -1722,7 +1722,7 @@ bool p3PeerMgrIMPL::setDynDNS(const RsPeerId &id, const std::string &dyndns)
     /* "it" points to peer */
     if (it->second.dyndns.compare(dyndns) != 0) {
         it->second.dyndns = dyndns;
-        IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
         changed = true;
     }
 
@@ -1961,7 +1961,7 @@ bool    p3PeerMgrIMPL::updateAddressList(const RsPeerId& id, const pqiIpAddrSet 
 	std::cerr << std::endl;
 #endif
 
-	IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 	return true;
 }
@@ -2005,7 +2005,7 @@ bool    p3PeerMgrIMPL::updateCurrentAddress(const RsPeerId& id, const pqiIpAddre
 	std::cerr << std::endl;
 #endif
 
-	IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+    IndicateConfigChanged(RsConfigMgr::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 	return true;
 }
@@ -2057,7 +2057,7 @@ bool    p3PeerMgrIMPL::setNetworkMode(const RsPeerId &id, uint32_t netMode)
 	if (it->second.netMode != netMode)
 	{
 		it->second.netMode = netMode;
-		IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+        IndicateConfigChanged(RsConfigMgr::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
 		changed = true;
 	}
 
@@ -2168,9 +2168,8 @@ bool    p3PeerMgrIMPL::setVisState(const RsPeerId &id, uint16_t vs_disc, uint16_
 		mLinkMgr->setFriendVisibility(id, vs_dht != RS_VS_DHT_OFF);
 	}
 
-	if (changed) {
-		IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
-	}
+    if (changed)
+        IndicateConfigChanged(RsConfigMgr::SAVE_LESS); /**** INDICATE MSG CONFIG CHANGED! *****/
 
 	return changed;
 }
@@ -2417,7 +2416,7 @@ bool p3PeerMgrIMPL::setMaxRates(const RsPgpId& pid,uint32_t maxUp,uint32_t maxDn
         p.max_up_rate_kbs = maxUp ;
         p.max_dl_rate_kbs = maxDn ;
 
-        IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_LESS);
 
         return true ;
 }
@@ -2704,7 +2703,7 @@ bool  p3PeerMgrIMPL::loadList(std::list<RsItem *>& load)
                     group_pair.second.peerIds.erase(profileIdIt);
                     profileIdIt=tmp;
 
-                    IndicateConfigChanged();
+                    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
                 }
         }
     }
@@ -2798,7 +2797,7 @@ bool p3PeerMgrIMPL::addGroup(RsGroupInfo &groupInfo)
 
 	RsServer::notify()->notifyListChange(NOTIFY_LIST_GROUPLIST, NOTIFY_TYPE_ADD);
 
-	IndicateConfigChanged();
+    IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 
 	return true;
 }
@@ -2838,7 +2837,7 @@ bool p3PeerMgrIMPL::editGroup(const RsNodeGroupId& groupId, RsGroupInfo &groupIn
     {
 		RsServer::notify()->notifyListChange(NOTIFY_LIST_GROUPLIST, NOTIFY_TYPE_MOD);
 
-		IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 	}
 
 	return changed;
@@ -2880,7 +2879,7 @@ bool p3PeerMgrIMPL::removeGroup(const RsNodeGroupId& groupId)
 	if (changed) {
 		RsServer::notify()->notifyListChange(NOTIFY_LIST_GROUPLIST, NOTIFY_TYPE_DEL);
 
-		IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 	}
 
 	return changed;
@@ -2968,7 +2967,7 @@ bool p3PeerMgrIMPL::assignPeersToGroup(const RsNodeGroupId &groupId, const std::
 	if (changed) {
 		RsServer::notify()->notifyListChange(NOTIFY_LIST_GROUPLIST, NOTIFY_TYPE_MOD);
 
-		IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 	}
 
 	return changed;
@@ -3022,7 +3021,7 @@ void p3PeerMgrIMPL::setServicePermissionFlags(const RsPgpId& pgp_id, const Servi
 		//
 
 		mFriendsPermissionFlags[pgp_id] = flags ;
-		IndicateConfigChanged(); /**** INDICATE MSG CONFIG CHANGED! *****/
+        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN); /**** INDICATE MSG CONFIG CHANGED! *****/
 }
 
 /**********************************************************************
@@ -3104,7 +3103,7 @@ bool p3PeerMgrIMPL::removeBannedIps()
     if(cleanIpList(mOwnState.ipAddrs.mLocal.mAddrs,mOwnState.id,mLinkMgr) )  changed = true ;
 
     if(changed)
-        IndicateConfigChanged();
+        IndicateConfigChanged(RsConfigMgr::SAVE_OFTEN);
 
     return true ;
 }

--- a/src/pqi/pqiindic.h
+++ b/src/pqi/pqiindic.h
@@ -23,35 +23,79 @@
 #define MRK_PQI_INDICATOR_HEADER
 
 #include <vector>
+#include <stdint.h>
 
-// This will indicate to num different sources
-// when the event has occured.
+// The Indicator class provides flags with different levels from 0 to n-1.
+//
+// Flags can be set at a specific level, and checked at all levels up to some
+// given level. As a consequence, it is possible to use these flags to conduct actions
+// at different priority levels: 0 has lowest priority, n-1 is highest.
 
 class Indicator
 {
-	public:
-	explicit Indicator(uint16_t n = 1)
-	:num(n), changeFlags(n) {IndicateChanged();}
-void	IndicateChanged()
-	{
-		for(uint16_t i = 0; i < num; i++)
-			changeFlags[i]=true;
-	}
+public:
+    explicit Indicator(uint16_t n = 1)
+            : changeFlags(n)
+    {
+        IndicateChanged();
+    }
 
-bool	Changed(uint16_t idx = 0)
-	{
-		/* catch overflow */
-		if (idx > num - 1)
-			return false;
+    /*!
+     * \brief IndicateChanged
+     * 			Sets all levels to 1.
+     */
+    void	IndicateChanged()
+    {
+        for(uint16_t i = 0; i < changeFlags.size(); i++)
+            changeFlags[i]=true;
+    }
 
-		bool ans = changeFlags[idx];
-		changeFlags[idx] = false;
-		return ans;
-	}
+    /*!
+     * \brief Reset
+     * 			Resets all flags.
+     */
+    void Reset()
+    {
+        for(uint32_t i=0;i<changeFlags.size();++i)
+            changeFlags[i]=false;
+    }
+    /*!
+     * \brief IndicateChanged
+     * 			Sets all levels up to level l. This reflects the fact that when checking,
+     *          any check that tests for lower urgency (meaning for less urgent business) needs to know that
+     *          a change has been made, so as to avoid other loops for more urgent business to also save.
+     * \param l
+     */
+    void	IndicateChanged(int l)
+    {
+        for(uint16_t i = 0; i <= l ; i++)
+            changeFlags[i]=true;
+    }
 
-	private:
-	uint16_t num;
-	std::vector<bool> changeFlags;
+    /*!
+     * \brief Changed
+     * 				Checks whether level idx or below has been changed, and reset *all*.
+     * 				This reflects the fact that once a level is positively checked, all levels
+     * 				need to be reset since the action does not need to be done again whatever its
+     * 				priority.
+     * \param idx
+     * \return
+     */
+    bool Changed(uint16_t idx = 0)
+    {
+        /* catch overflow */
+
+        bool ans = changeFlags[idx];
+
+        if(ans)
+            for(uint32_t i=0;i<changeFlags.size();++i)
+                changeFlags[i] = false;
+
+        return ans;
+    }
+
+private:
+    std::vector<bool> changeFlags;
 };
 
 

--- a/src/pqi/pqiindic.h
+++ b/src/pqi/pqiindic.h
@@ -24,18 +24,19 @@
 
 #include <vector>
 #include <stdint.h>
+#include <assert.h>
 
-// The Indicator class provides flags with different levels from 0 to n-1.
+// The Indicator class provides flags with different levels from 0 to 31.
 //
 // Flags can be set at a specific level, and checked at all levels up to some
 // given level. As a consequence, it is possible to use these flags to conduct actions
-// at different priority levels: 0 has lowest priority, n-1 is highest.
+// at different priority levels: 0 has lowest priority, 31 has highest.
 
 class Indicator
 {
 public:
-    explicit Indicator(uint16_t n = 1)
-            : changeFlags(n)
+    explicit Indicator()
+            : changeFlags(0)
     {
         IndicateChanged();
     }
@@ -46,8 +47,7 @@ public:
      */
     void	IndicateChanged()
     {
-        for(uint16_t i = 0; i < changeFlags.size(); i++)
-            changeFlags[i]=true;
+        changeFlags=~0;
     }
 
     /*!
@@ -56,8 +56,7 @@ public:
      */
     void Reset()
     {
-        for(uint32_t i=0;i<changeFlags.size();++i)
-            changeFlags[i]=false;
+        changeFlags=0;
     }
     /*!
      * \brief IndicateChanged
@@ -66,36 +65,35 @@ public:
      *          a change has been made, so as to avoid other loops for more urgent business to also save.
      * \param l
      */
-    void	IndicateChanged(int l)
+    void	IndicateChanged(uint8_t l)
     {
-        for(uint16_t i = 0; i <= l ; i++)
-            changeFlags[i]=true;
+        assert(l < 31);
+        changeFlags |= (1u << (l+1))-1;
     }
 
     /*!
      * \brief Changed
-     * 				Checks whether level idx or below has been changed, and reset *all*.
+     * 				Checks whether level idx or below has been changed, and reset *all* levels.
      * 				This reflects the fact that once a level is positively checked, all levels
-     * 				need to be reset since the action does not need to be done again whatever its
-     * 				priority.
+     * 				need to be reset since the action is considered done.
      * \param idx
      * \return
      */
-    bool Changed(uint16_t idx = 0)
+    bool Changed(uint8_t idx = 0)
     {
         /* catch overflow */
+        assert(idx < 32);
 
-        bool ans = changeFlags[idx];
+        bool ans(changeFlags & (1u << idx));
 
         if(ans)
-            for(uint32_t i=0;i<changeFlags.size();++i)
-                changeFlags[i] = false;
+            changeFlags = 0;
 
         return ans;
     }
 
 private:
-    std::vector<bool> changeFlags;
+    uint32_t changeFlags;
 };
 
 

--- a/src/retroshare/rsconfig.h
+++ b/src/retroshare/rsconfig.h
@@ -433,7 +433,7 @@ public:
 	 * @param[out] outKbWhenIdle upload rate in kB When Idle
 	 * @return returns 1 on succes and 0 otherwise
 	 */
-	virtual int getMaxDataRates( int &inKb, int &outKb, int &inKbWhenIdle, int &outKbWhenIdle) = 0;
+    virtual int getMaxDataRates( int& inKb, int& outKb, int& inKbWhenIdle, int& outKbWhenIdle) = 0;
 
 	/**
 	 * @brief GetCurrentDataRates get current upload and download rates
@@ -451,6 +451,18 @@ public:
 	 * @param[in] isIdle
 	 */
 	virtual void setIsIdle(bool isIdle) = 0;
+};
+
+class RsConfigMgr
+{
+public:
+    enum CheckPriority {
+                        UNKNOWN           = 0x00,
+                        SAVE_WHEN_CLOSING = 0x01,
+                        SAVE_LESS         = 0x02,
+                        SAVE_OFTEN        = 0x03,
+                        SAVE_NOW          = 0x04
+    };
 };
 
 #endif

--- a/src/retroshare/rsconfig.h
+++ b/src/retroshare/rsconfig.h
@@ -453,10 +453,13 @@ public:
 	virtual void setIsIdle(bool isIdle) = 0;
 };
 
+// I use a class here because it's likely that we will need methods to provide global behavior switches
+// on Config Managing system.
+
 class RsConfigMgr
 {
 public:
-    enum CheckPriority {
+    enum class CheckPriority:uint8_t {
                         UNKNOWN           = 0x00,	// placeholder
                         SAVE_WHEN_CLOSING = 0x01,	// Means we do not care if configuration is lost on crash.
                         SAVE_LESS         = 0x02,	// Save every hour. Not very important changes (GXS data, etc)

--- a/src/retroshare/rsconfig.h
+++ b/src/retroshare/rsconfig.h
@@ -457,11 +457,11 @@ class RsConfigMgr
 {
 public:
     enum CheckPriority {
-                        UNKNOWN           = 0x00,
-                        SAVE_WHEN_CLOSING = 0x01,
-                        SAVE_LESS         = 0x02,
-                        SAVE_OFTEN        = 0x03,
-                        SAVE_NOW          = 0x04
+                        UNKNOWN           = 0x00,	// placeholder
+                        SAVE_WHEN_CLOSING = 0x01,	// Means we do not care if configuration is lost on crash.
+                        SAVE_LESS         = 0x02,	// Save every hour. Not very important changes (GXS data, etc)
+                        SAVE_OFTEN        = 0x03,	// For GUI configuration, so that it's saved within 1 min.
+                        SAVE_NOW          = 0x04	// Stuff we do not want to re-do on crash: adding friends, file transfers, etc.
     };
 };
 

--- a/src/rsserver/p3face-server.cc
+++ b/src/rsserver/p3face-server.cc
@@ -184,7 +184,7 @@ void RsServer::threadTick()
 #ifdef TICK_DEBUG
 		RsDbg() << "TICK_DEBUG every second";
 #endif
-        mConfigMgr->tick(RsConfigMgr::SAVE_NOW); // This most of the time does nothing, since it only saved the urgent ones, which is not the default.
+        mConfigMgr->tick(RsConfigMgr::CheckPriority::SAVE_NOW); // This most of the time does nothing, since it only saved the urgent ones, which is not the default.
 
         // slow services
 		if (rsPlugins)
@@ -208,7 +208,6 @@ void RsServer::threadTick()
 		RsDbg() << "TICK_DEBUG every 5 seconds";
 #endif
 		mCycle2 = ts;
-        mConfigMgr->tick(RsConfigMgr::SAVE_NOW); // This most of the time does nothing, since it only saved the urgent ones, which is not the default.
     }
 
 // stuff we do every minute
@@ -222,7 +221,7 @@ void RsServer::threadTick()
 		// see if we need to resave certs
 		// AuthSSL::getAuthSSL()->CheckSaveCertificates();
 		mCycle3 = ts;
-        mConfigMgr->tick(RsConfigMgr::SAVE_OFTEN); // This most of the time does nothing, since it only saved the urgent ones, which is not the default.
+        mConfigMgr->tick(RsConfigMgr::CheckPriority::SAVE_OFTEN); // This most of the time does nothing, since it only saved the urgent ones, which is not the default.
     }
 
 // stuff we do every hour
@@ -236,7 +235,7 @@ void RsServer::threadTick()
 		RsDbg() << "TICK_DEBUG ticking mConfigMgr";
 #endif
 		mCycle4 = ts;
-        mConfigMgr->tick(RsConfigMgr::SAVE_LESS); // This most of the time does nothing, since it only saved the urgent ones, which is not the default.
+        mConfigMgr->tick(RsConfigMgr::CheckPriority::SAVE_LESS); // This most of the time does nothing, since it only saved the urgent ones, which is not the default.
     }
 
 // ticking is done, now compute new values of mLastRunDuration, mAvgRunDuration and mTickInterval

--- a/src/rsserver/p3face-server.cc
+++ b/src/rsserver/p3face-server.cc
@@ -184,7 +184,9 @@ void RsServer::threadTick()
 #ifdef TICK_DEBUG
 		RsDbg() << "TICK_DEBUG every second";
 #endif
-		// slow services
+        mConfigMgr->tick(RsConfigMgr::SAVE_NOW); // This most of the time does nothing, since it only saved the urgent ones, which is not the default.
+
+        // slow services
 		if (rsPlugins)
 		{
 #ifdef TICK_DEBUG
@@ -206,7 +208,8 @@ void RsServer::threadTick()
 		RsDbg() << "TICK_DEBUG every 5 seconds";
 #endif
 		mCycle2 = ts;
-	}
+        mConfigMgr->tick(RsConfigMgr::SAVE_NOW); // This most of the time does nothing, since it only saved the urgent ones, which is not the default.
+    }
 
 // stuff we do every minute
 	if (ts - mCycle3 > 60)
@@ -219,7 +222,8 @@ void RsServer::threadTick()
 		// see if we need to resave certs
 		// AuthSSL::getAuthSSL()->CheckSaveCertificates();
 		mCycle3 = ts;
-	}
+        mConfigMgr->tick(RsConfigMgr::SAVE_OFTEN); // This most of the time does nothing, since it only saved the urgent ones, which is not the default.
+    }
 
 // stuff we do every hour
 	if (ts - mCycle4 > 3600)
@@ -231,9 +235,9 @@ void RsServer::threadTick()
 #ifdef TICK_DEBUG
 		RsDbg() << "TICK_DEBUG ticking mConfigMgr";
 #endif
-		mConfigMgr->tick();
 		mCycle4 = ts;
-	}
+        mConfigMgr->tick(RsConfigMgr::SAVE_LESS); // This most of the time does nothing, since it only saved the urgent ones, which is not the default.
+    }
 
 // ticking is done, now compute new values of mLastRunDuration, mAvgRunDuration and mTickInterval
 	ts = getCurrentTS();


### PR DESCRIPTION
IndicateConfigChanged() now takes an optional parameter asking for save with more or less priority, among SAVE_WHEN_CLOSING (the default, as before), SAVE_LESS (every hour), SAVE_OFTEN (every 1 min), SAVE_NOW (immediately).

Currently only FT has been set to SAVE_NOW, so that changes to file transfers are not lost on crash.

Generally, changes due to user config changes in the UI should use SAVE_OFTEN, while GXS data changes can use SAVE_LESS.
