### PR TITLE
pqi: history: swap sending and host sides in right order for distant chat

### DIFF
--- a/src/pqi/p3historymgr.cc
+++ b/src/pqi/p3historymgr.cc
@@ -104,7 +104,7 @@ void p3HistoryMgr::addMessage(const ChatMessage& cm)
 				else
 					peerName = writer_id.toStdString();
 
-				msgPeerId = cm.incoming?RsPeerId(dcpinfo.own_id):RsPeerId(dcpinfo.to_id);
+				msgPeerId = cm.incoming ? RsPeerId(dcpinfo.to_id) : RsPeerId(dcpinfo.own_id);
 			}
 			else
 			{


### PR DESCRIPTION
Since 2021. Nobody really uses such thing