### PR TITLE
Fix + SAMv3 update

### DIFF
--- a/src/serialiser/rstypeserializer.h
+++ b/src/serialiser/rstypeserializer.h
@@ -141,7 +141,6 @@ struct RsTypeSerializer
 					        << std::error_condition(std::errc::no_buffer_space)
 					        << std::endl;
 					print_stacktrace();
-					exit(-1);
 					break;
 				}
 				memcpy(&member, ctx.mData + ctx.mOffset, sizeof(INTT));

--- a/src/services/autoproxy/p3i2psam3.cpp
+++ b/src/services/autoproxy/p3i2psam3.cpp
@@ -483,6 +483,8 @@ bool p3I2pSam3::startSession()
 		// backup quantity
 		params.push_back(i2p::makeOption("inbound.backupQuantity", + mSetting.inBackupQuantity));
 		params.push_back(i2p::makeOption("outbound.backupQuantity", + mSetting.outBackupQuantity));
+		// lease set type (support encrypted one, too)
+		params.push_back("i2cp.leaseSetEncType=0,4");
 	}
 
 	std::string paramsStr;

--- a/src/services/autoproxy/rsautoproxymonitor.cc
+++ b/src/services/autoproxy/rsautoproxymonitor.cc
@@ -323,7 +323,8 @@ autoProxyService *rsAutoProxyMonitor::lookUpService(autoProxyType::autoProxyType
 	if ((itService = mProxies.find(t)) != mProxies.end()) {
 		return itService->second;
 	}
-	RS_DBG("no service for type ", t, " found!");
+	if (!mRSShutDown)
+		RS_DBG("no service for type ", t, " found!");
 	return NULL;
 }
 


### PR DESCRIPTION
- There was an leftover `exit -1;` which crashes RS. Remove it since RS handles the error case well.
- User "I2P" pointed out that there are connection problems involving i2p encrypted lease sets. [i2psam](https://github.com/i2p/i2psam/blob/a09ab6b4841031b18be88b9b32d89d6be881daef/i2psam.h#L54) sets this per default `"i2cp.leaseSetEncType=0,4"` , do the same in RS
- A warning is silenced when shutting down. The warning is _expected_ when shutting down and therefore missleading.