### PR TITLE
Improve thread names for gxs trans cleanup and gxs integrity check

### DIFF
--- a/src/gxs/rsgenexchange.cc
+++ b/src/gxs/rsgenexchange.cc
@@ -43,6 +43,9 @@
 #include "util/radix64.h"
 #include "util/cxx17retrocompat.h"
 
+#include <iostream>
+#include <sstream>
+
 #define PUB_GRP_MASK     0x000f
 #define RESTR_GRP_MASK   0x00f0
 #define PRIV_GRP_MASK    0x0f00
@@ -323,8 +326,9 @@ void RsGenExchange::tick()
 			{
 				mIntegrityCheck = new RsGxsIntegrityCheck( mDataStore, this,
 				                                           *mSerialiser, mGixs);
-				std::string thisName = typeid(*this).name();
-				mChecking = mIntegrityCheck->start("gxs IC4 "+thisName);
+				std::stringstream ss;
+				ss << std::hex << mServType;
+				mChecking = mIntegrityCheck->start("gxs int chk "+ss.str());
 			}
 		}
 

--- a/src/gxstrans/p3gxstrans.cc
+++ b/src/gxstrans/p3gxstrans.cc
@@ -500,7 +500,7 @@ void p3GxsTrans::service_tick()
             std::cerr << "Starting GxsIntegrity cleanup thread." << std::endl;
 #endif
 
-			mCleanupThread->start() ;
+	    mCleanupThread->start("gxs trans clean") ;
             mLastMsgCleanup = now ;
         }
 


### PR DESCRIPTION
- gxs trans cleanup thread was running without a name - > now "gxs trans clean"
- gxs integrity check thread was using a somehow cryptic name -> "gxs int chk 217" (as an example)
- maximum length for a thread name is 15 chars