### PR TITLE
Fixes for macOS + some non-functional improvements to text (typos, spaces)

### DIFF
--- a/src/util/contentvalue.h
+++ b/src/util/contentvalue.h
@@ -49,7 +49,7 @@ public:
      * makes a deep copy of raw data
      * @param from ContentValue instance to copy key value set from
      */
-    ContentValue(const ContentValue& from);//const damit die äußere klasse einen konstruktor com compielr bekommt
+    ContentValue(const ContentValue& from); //const damit die äußere klasse einen konstruktor com compielr bekommt
 
     /*!
      *
@@ -63,7 +63,7 @@ public:
      * @param key  the name of the value to put
      * @param value  the data for the value to put
      * @warning cast string literals explicitly as string, observed string literal \n
-     *          being casted to bool instead e.g. string("hello") rather than "hello"
+     *          being casted to bool instead, e.g. string("hello") rather than "hello"
      */
     void put(const std::string& key, const std::string& value);
 
@@ -105,13 +105,13 @@ public:
 
 
     /*!
-     * get value as 32 bit signed integer
+     * get value as 32-bit signed integer
      * @param key the value to get
      */
     bool getAsInt32(const std::string& key, int32_t& value) const;
 
     /*!
-     * get value as 64 bit signed integer
+     * get value as 64-bit signed integer
      * @param key the value to get
      */
     bool getAsInt64(const std::string& key, int64_t& value) const;

--- a/src/util/cxx23retrocompat.h
+++ b/src/util/cxx23retrocompat.h
@@ -20,11 +20,12 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
+
 #pragma once
 
 #include <utility>
 
-#if ! defined(__cpp_lib_to_underlying)
+#if !defined(__cpp_lib_to_underlying)
 #	include <type_traits>
 namespace std
 {
@@ -32,4 +33,4 @@ template <class Enum>
 constexpr underlying_type_t<Enum> to_underlying(Enum e) noexcept
 { return static_cast<std::underlying_type_t<Enum>>(e); }
 }
-#endif // ! defined(__cpp_lib_to_underlying)
+#endif // !defined(__cpp_lib_to_underlying)

--- a/src/util/dnsresolver.cc
+++ b/src/util/dnsresolver.cc
@@ -19,11 +19,11 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
+
 #include "dnsresolver.h"
 
 #include "pqi/pqinetwork.h"
 #include "util/rsnet.h"
-
 
 #ifndef WIN32
 #include <netdb.h>
@@ -199,4 +199,3 @@ DNSResolver::DNSResolver() : _rdnsMtx("DNSResolver")
 	_thread_running = new bool ;
 	*_thread_running = false ;
 }
-

--- a/src/util/rsdbbind.cc
+++ b/src/util/rsdbbind.cc
@@ -19,6 +19,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
+
 #include "rsdbbind.h"
 
 RsDoubleBind::RsDoubleBind(double value, int index)
@@ -68,4 +69,3 @@ bool RsBlobBind::bind(sqlite3_stmt* const stm) const
 {
 	return (SQLITE_OK == sqlite3_bind_blob(stm, getIndex(), mData, mDataLen, SQLITE_TRANSIENT));
 }
-

--- a/src/util/rsdbbind.h
+++ b/src/util/rsdbbind.h
@@ -19,6 +19,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
+
 #ifndef RSDBBIND_H_
 #define RSDBBIND_H_
 
@@ -96,6 +97,5 @@ public:
 	char* mData;
 	uint32_t mDataLen;
 };
-
 
 #endif /* RSDBBIND_H_ */

--- a/src/util/rsdnsutils.cc
+++ b/src/util/rsdnsutils.cc
@@ -33,6 +33,20 @@
 #include <netdb.h>
 #endif
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1070
+static size_t strnlen(const char *s, size_t maxlength) {
+  size_t l = 0;
+  while (l < maxlength && *s) {
+    l++;
+    s++;
+  }
+  return l;
+}
+#endif
+#endif
+
 //https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-2
 constexpr uint16_t DNSC_IN    = 1; //Internet (IN)
 

--- a/src/util/rsdnsutils.cc
+++ b/src/util/rsdnsutils.cc
@@ -50,7 +50,7 @@ static size_t strnlen(const char *s, size_t maxlength) {
 //https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-2
 constexpr uint16_t DNSC_IN    = 1; //Internet (IN)
 
-///Need to pack as we use sizeof them. (avoid padding)
+//Need to pack as we use sizeof them (avoid padding)
 #pragma pack(1)
 //DNS header structure
 struct DNS_HEADER
@@ -105,7 +105,7 @@ struct RR_DATA
 {
     unsigned short rtype;   //https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
     unsigned short rclass;  //https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-2
-    unsigned int rttl;      //Time To Live is the number of seconds left before the information expires. (32bits integer, so maximum 140 years)
+    unsigned int rttl;      //Time To Live is the number of seconds left before the information expires (32-bits integer, so maximum 140 years)
     unsigned short data_len;//Lenght of following data
 };
 #pragma pack()

--- a/src/util/rsfile.h
+++ b/src/util/rsfile.h
@@ -24,6 +24,11 @@
 
 #include <stdio.h>
 
+#ifndef WINDOWS_SYS
+#include <sys/types.h>
+#include <sys/socket.h>
+#endif
+
 namespace RsFileUtil {
 
 int set_fd_nonblock(int fd);

--- a/src/util/rsmacrosugar.hpp
+++ b/src/util/rsmacrosugar.hpp
@@ -19,13 +19,13 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#pragma once
 
+#pragma once
 
 /** Comfortable optional variadic macro arguments
  * @see https://www.appsloveworld.com/cplus/100/16/variadic-macros-with-zero-arguments
- * C/C++ variadic macros gives error on expansion if no argument is passed, the
- * result is that at least one argument must be passed or compilation fails.
+ * C/C++ variadic macros gives error on expansion if no argument is passed,
+ * the result is that at least one argument must be passed or compilation fails.
  * Wrapping __VA_ARGS__ in RS_OPT_VA_ARGS at expansion place omitting the comma
  * before solves this issue rendering the variadic arguments effectively
  * optionals.
@@ -40,4 +40,3 @@
 
 /// Concatenate preprocessor tokens A and B after macro-expanding them.
 #define RS_CONCAT_MACRO(A, B) RS_CONCAT_MACRO_NX(A, B)
-

--- a/src/util/rsmemcache.h
+++ b/src/util/rsmemcache.h
@@ -487,6 +487,4 @@ template<class Key, class Value> void RsMemCache<Key, Value>::clearStats()
 }
 
 
-
-
 #endif // RS_UTIL_MEM_CACHE

--- a/src/util/rsrandom.h
+++ b/src/util/rsrandom.h
@@ -19,8 +19,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
-#pragma once
 
+#pragma once
 
 #include <vector>
 #include <cstdint>
@@ -30,7 +30,7 @@
 
 /**
  * RsRandom provide a random number generator that is
- * - thread safe
+ * - thread-safe
  * - platform independent
  * - fast
  * - CRYPTOGRAPHICALLY SAFE, because it is based on openssl random number
@@ -46,12 +46,12 @@ public:
 
 	static bool     seed(uint32_t s);
 
-	static void        random_bytes(uint8_t* data, uint32_t length);
+	static void     random_bytes(uint8_t* data, uint32_t length);
 
-	/// Return a random alphanumeric *[0-9,A-Z,a-z] string of the given lenght
+	/// Return a random alphanumeric *[0-9,A-Z,a-z] string of the given length
 	static std::string alphaNumeric(uint32_t length);
 
-	/** Return a random printable string of the given lenght */
+	/** Return a random printable string of the given length */
 	static std::string printable(uint32_t length);
 
 	/** This return a printable string not an alphanumeric one @deprecated */

--- a/src/util/rsstring.cc
+++ b/src/util/rsstring.cc
@@ -19,6 +19,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
+
 #include "rsstring.h"
 
 #ifdef WINDOWS_SYS
@@ -320,8 +321,6 @@ void stringToLowerCase(const std::string& s, std::string &lower)
 			lower[i] += 97-65 ;
 }
 
-
-
 bool isHexaString(const std::string& s)
 {
 	for(uint32_t i=0;i<s.length();++i)
@@ -330,5 +329,3 @@ bool isHexaString(const std::string& s)
 
 	return true ;
 }
-
-

--- a/src/util/rstime.h
+++ b/src/util/rstime.h
@@ -20,14 +20,17 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
+
 #pragma once
 
 #include <string>
+
 #ifdef WINDOWS_SYS
 #include <stdint.h>
 #else
 #include <cstdint>
 #endif
+
 #include <ctime> // Added for comfort of users of this util header
 #include "util/rsdeprecate.h"
 
@@ -37,7 +40,7 @@
  * is not guaranted to be the same but we found it being number of seconds since
  * the epoch for time points in all platforms we could test, or plain seconds
  * for intervals.
- * Still in some platforms it's 32bit long and in other 64bit long.
+ * Still in some platforms it's 32-bit long and in other 64-bit long.
  * To avoid uncompatibility due to different serialzation format use this
  * reasonably safe alternative instead.
  */
@@ -50,7 +53,7 @@ namespace rstime {
  * @deprecated { std::this_thread::sleep_for or
  * std::this_thread::sleep_until instead }
  * @brief This is a cross-system definition of usleep, which accepts any
- * 32 bits number of micro-seconds.
+ * 32-bit number of micro-seconds.
  */
 RS_DEPRECATED_FOR("std::this_thread::sleep_for")
 int rs_usleep(uint32_t micro_seconds);

--- a/src/util/rsurl.cc
+++ b/src/util/rsurl.cc
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include <cstdio>
 #include <algorithm>
 #include <iostream>
@@ -301,4 +300,3 @@ void RsUrl::serial_process( RsGenericSerializer::SerializeJob j,
 /*static*/ const std::string RsUrl::queryAssign("=");
 /*static*/ const std::string RsUrl::queryFieldSep("&");
 /*static*/ const std::string RsUrl::fragmentSeparator("#");
-

--- a/src/util/smallobject.cc
+++ b/src/util/smallobject.cc
@@ -19,6 +19,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
+
 #include <iostream>
 #include "smallobject.h"
 #include "util/rsthreads.h"
@@ -345,5 +346,3 @@ void RsMemoryManagement::printStatistics()
 {
 	SmallObject::printStatistics();
 }
-
-

--- a/src/util/smallobject.h
+++ b/src/util/smallobject.h
@@ -19,6 +19,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
  *                                                                             *
  *******************************************************************************/
+
 #pragma once
 
 #include <stdlib.h>
@@ -112,5 +113,3 @@ namespace RsMemoryManagement
 
 	extern void printStatistics() ;
 }
-
-

--- a/src/util/stacktrace.h
+++ b/src/util/stacktrace.h
@@ -30,10 +30,10 @@
 
 /**
  * @brief Print a backtrace to FILE* out.
- * @param[in] demangle true to demangle C++ symbols requires malloc working, in
- *	some patological cases like a SIGSEGV received during a malloc this would
- *	cause deadlock so pass false if you may be in such situation (like in a
- *	SIGSEGV handler )
+ * @param[in] demangle true to demangle C++ symbols requires malloc working,
+ *	in some patological cases like a SIGSEGV received during a malloc this
+ *	would cause deadlock so pass false if you may be in such situation
+ *	(like in a SIGSEGV handler)
  * @param[in] out output file
  * @param[in] maxFrames maximum number of stack frames you want to bu printed
  */
@@ -90,8 +90,8 @@ static void print_stacktrace(
 	size_t funcnamesize = 256;
 	char* funcname = (char*)malloc(funcnamesize);
 
-	// iterate over the returned symbol lines. skip the first, it is the
-	// address of this function.
+	// iterate over the returned symbol lines. skip the first, it is
+	// the address of this function.
 	for (int i = 1; i < addrlen; i++)
 	{
 		char *begin_name = 0, *begin_offset = 0, *end_offset = 0;
@@ -131,8 +131,8 @@ static void print_stacktrace(
 			}
 			else
 			{
-				// demangling failed. Output function name as a C function with
-				// no arguments.
+				// demangling failed. Output function name as a C function
+				// with no arguments.
 				fprintf( out, "  %s : %s()+%s\n",
 				         symbollist[i], begin_name, begin_offset );
 			}
@@ -149,7 +149,7 @@ static void print_stacktrace(
 }
 #elif defined(__ANDROID__) // defined(__linux__) && defined(__GLIBC__)
 
-/* Inspired by the solution proposed by Louis Semprini  on this thread
+/* Inspired by the solution proposed by Louis Semprini on this thread
  * https://stackoverflow.com/questions/8115192/android-ndk-getting-the-backtrace/35586148
  */
 
@@ -200,8 +200,8 @@ static void print_stacktrace(
 
 		/* Ignore null addresses.
 		 * They sometimes happen when using _Unwind_Backtrace()
-		 * with compiler optimizations, when the Link Register is overwritten by
-		 * the inner stack frames. */
+		 * with compiler optimizations, when the Link Register is overwritten
+		 * by the inner stack frames. */
 		if(!addr) continue;
 
 		/* Ignore duplicate addresses.
@@ -249,8 +249,8 @@ static void print_stacktrace(
 	/** Notify the user which signal was caught. We use printf, because this
 	 * is the most basic output function. Once you get a crash, it is
 	 * possible that more complex output systems like streams and the like
-	 * may be corrupted. So we make the most basic call possible to the
-	 * lowest level, most standard print function. */
+	 * may be corrupted. So we make the most basic call possible
+	 * to the lowest level, most standard print function. */
 	fprintf(out, "print_stacktrace Not implemented yet for this platform\n");
 }
 #endif // defined(__linux__) && defined(__GLIBC__)
@@ -292,8 +292,8 @@ struct CrashStackTrace
 		/** Notify the user which signal was caught. We use printf, because this
 		 * is the most basic output function. Once you get a crash, it is
 		 * possible that more complex output systems like streams and the like
-		 * may be corrupted. So we make the most basic call possible to the
-		 * lowest level, most standard print function. */
+		 * may be corrupted. So we make the most basic call possible
+		 * to the lowest level, most standard print function. */
 		if(name)
 			fprintf(stderr, "Caught signal %d (%s)\n", signum, name);
 		else
@@ -309,4 +309,3 @@ struct CrashStackTrace
 		exit(-signum);
 	}
 };
-


### PR DESCRIPTION
Fix for: https://github.com/RetroShare/libretroshare/issues/72
Fix for missing `strnlen`.
Non-functional improvements to text (few typos corrected etc.)

P. S. One remaining thing to fix for older macOS is missing `getline`. I will find a suitable implementation a bit later (likely our Macports one from `legacysupport` will do).