### PR TITLE
Introduced a new variable named mMaxAutoDownloadSize which is used store the maximum size allowed for auto download in channel.

### DIFF
--- a/src/retroshare/rsgxschannels.h
+++ b/src/retroshare/rsgxschannels.h
@@ -553,7 +553,7 @@ public:
      *          data request ongoing and data available
      */
     virtual DistantSearchGroupStatus getDistantSearchStatus(const RsGxsGroupId& group_id) =0;
-
+    
     /**
 	 * @brief Clear accumulated search results
 	 * @jsonapi{development}
@@ -561,6 +561,21 @@ public:
 	 * @return false on error, true otherwise
 	 */
 	virtual bool clearDistantSearchResults(TurtleRequestId reqId) = 0;
+
+    /**
+     * @brief getMaxAutoDownloadSizeLimit
+     * 			retrieves the maximum size allowed for auto download in channels
+     */
+    virtual bool getMaxAutoDownloadSizeLimit(uint64_t& store)=0;
+
+    /**
+     * @brief setMaxAutoDownloadSizeLimit
+     * 			updates the maximum size allowed for
+     *
+     *  auto download in channels
+     */
+    virtual bool setMaxAutoDownloadSizeLimit(uint64_t size)=0;
+
 
 	~RsGxsChannels() override;
 

--- a/src/services/p3gxschannels.h
+++ b/src/services/p3gxschannels.h
@@ -24,9 +24,12 @@
 
 
 #include "retroshare/rsgxschannels.h"
+
 #include "services/p3gxscommon.h"
+
 #include "gxs/rsgenexchange.h"
 #include "gxs/gxstokenqueue.h"
+
 #include "util/rsmemory.h"
 #include "util/rsdebug.h"
 #include "util/rstickevent.h"
@@ -34,6 +37,8 @@
 #include <map>
 #include <string>
 
+// This macro defines 8gb as the default value for auto download in channels
+#define CHANNEL_MAX_AUTO_DL		                            (8 * 1024 * 1024 * 1024ull)	// 8 GB. Just a security ;-)
 
 // This class is only a helper to parse the channel group service string.
 
@@ -393,6 +398,18 @@ private:
     rstime_t mLastDistantSearchNotificationTS;
 
     std::map<TurtleRequestId,std::set<RsGxsGroupId> > mSearchResultsToNotify;
+
+    // Variable for storing the size allowed for auto download in channels (initialized with 8 gb)
+    uint64_t mMaxAutoDownloadSize = CHANNEL_MAX_AUTO_DL;
+
+    public:
+
+        // Function to retrieve the maximum size allowed for auto download in channels
+        virtual bool getMaxAutoDownloadSizeLimit(uint64_t& store) override;
+
+        // Function to update the maximum size allowed for auto download in channels
+        virtual bool setMaxAutoDownloadSizeLimit(uint64_t size) override;
+
 #ifdef TO_REMOVE
     /** Store search callbacks with timeout*/
     std::map<


### PR DESCRIPTION
The functions to update it and retrieve it were also introduced. This variable was also added in the saving and loading configuration mechanism.