### PR TITLE
Define USE_OPENPGPSDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ CMakeLists.txt.user
 # Build artifacts
 Makefile.libretroshare
 *.a
+*.o

--- a/src/use_libretroshare.pri
+++ b/src/use_libretroshare.pri
@@ -36,6 +36,7 @@ isEmpty(RAPIDJSON_AVAILABLE) {
 
 rs_openpgpsdk {
         !include("../../openpgpsdk/src/use_openpgpsdk.pri"):error("Including")
+        DEFINES *= USE_OPENPGPSDK
 }
 
 sLibs =


### PR DESCRIPTION
It seems that `USE_OPENPGPSDK` was not properly defined when including libretroshare from retroshare-friendserver.

I also added the *.o build artifacts to .gitignore.