### PR TITLE
add missing include for Windows

### DIFF
--- a/src/util/rswin.h
+++ b/src/util/rswin.h
@@ -32,6 +32,7 @@
 
 #include <windows.h>
 #include <string>
+#include <sys/stat.h>
 
 // For win32 systems (tested on MingW+Ubuntu)
 #undef stat64


### PR DESCRIPTION
tested on: Windows 11 with windos-msys2/buil.bat, Debian 12, MacOs 15.5