### PR TITLE
fix botan path

### DIFF
--- a/src/libretroshare.pro
+++ b/src/libretroshare.pro
@@ -1187,8 +1187,8 @@ message("In rnp_rnplib precompilation code")
 		LIBRNP_CMAKE_PARAMS *= "-DJSON-C_LIBRARY=$$clean_path(/usr/local/opt/json-c/lib/libjson-c.a)"
 		LIBRNP_CMAKE_PARAMS *= "-DJSON-C_VERSION=0.18"
 		# botan
-		LIBRNP_CMAKE_PARAMS *= "-DBOTAN_INCLUDE_DIR=$$clean_path(/usr/local/opt/botan@2/include/botan-2)"
-		LIBRNP_CMAKE_PARAMS *= "-DBOTAN_LIBRARY=$$clean_path(/usr/local/opt/botan@2/lib/libbotan-2.a)"
+		LIBRNP_CMAKE_PARAMS *= "-DBOTAN_INCLUDE_DIR=$$clean_path(/usr/local/Cellar/botan@2/2.19.5/include/botan-2)"
+		LIBRNP_CMAKE_PARAMS *= "-DBOTAN_LIBRARY=$$clean_path(/usr/local/Cellar/botan@2/2.19.5/lib)"
 		# set minimum Mac Version to not get different endresults of min versions
 		LIBRNP_CMAKE_CXXFLAGS = -mmacosx-version-min=10.13
 	}


### PR DESCRIPTION
with this changes it gets work with botan@2 bigint issue but on local mac machine
but on workflow installed botan include & lib are installed on different path not sure how we can handle this?

<img width="610" height="190" alt="image" src="https://github.com/user-attachments/assets/60dbba4a-6628-4dcb-807b-39946793dcb4" />


`/opt/homebrew/Cellar/botan@2/2.19.5 
`

```
For compilers to find botan@2 you may need to set:
  export LDFLAGS="-L/opt/homebrew/opt/botan@2/lib"
  export CPPFLAGS="-I/opt/homebrew/opt/botan@2/include"
```
