### PR TITLE
File upload stats

### DIFF
--- a/src/ft/ftserver.cc
+++ b/src/ft/ftserver.cc
@@ -41,6 +41,7 @@
 #include "ft/ftturtlefiletransferitem.h"
 
 #include "pqi/p3linkmgr.h"
+#include "pqi/p3notify.h"
 #include "pqi/pqi.h"
 
 #include "retroshare/rstypes.h"
@@ -1316,6 +1317,15 @@ bool	ftServer::sendData(const RsPeerId& peerId, const RsFileHash& hash, uint64_t
 		offset += chunk;
 		tosend -= chunk;
 	}
+	std::map<RsFileHash,uint64_t>::iterator it = cumulative_uploaded.find(hash) ;
+	if(it != cumulative_uploaded.end())
+	{
+		it->second += chunksize;
+	}
+	else
+	{
+		cumulative_uploaded.insert(std::make_pair(hash,(uint64_t)chunksize)) ;
+	}
 
 	/* clean up data */
 	free(data);
@@ -2342,4 +2352,27 @@ std::error_condition ftServer::parseFilesLink(
 	std::tie(tft, ec) = RsFileTree::fromBase64(*radixPtr);
 	if(tft) collection = *tft;
 	return ec;
+}
+
+uint64_t ftServer::getCumulativeUpload(RsFileHash hash)
+{
+	RS_STACK_MUTEX(srvMutex);
+	std::map<RsFileHash,uint64_t>::iterator it = cumulative_uploaded.find(hash) ;
+	if(it != cumulative_uploaded.end())
+		return it->second;
+	return 0;
+}
+
+uint64_t ftServer::getCumulativeUploadAll()
+{
+	RS_STACK_MUTEX(srvMutex);
+	uint64_t all = 0;
+	for(std::map<RsFileHash,uint64_t>::iterator it(cumulative_uploaded.begin()); it!=cumulative_uploaded.end(); ++it)
+		all += it->second;
+	return all;
+}
+
+uint64_t ftServer::getCumulativeUploadNum()
+{
+	return cumulative_uploaded.size();
 }

--- a/src/ft/ftserver.h
+++ b/src/ft/ftserver.h
@@ -364,6 +364,10 @@ public:
     bool encryptItem(RsTurtleGenericTunnelItem *clear_item,const RsFileHash& hash,RsTurtleGenericDataItem *& encrypted_item);
     bool decryptItem(const RsTurtleGenericDataItem *encrypted_item, const RsFileHash& hash, RsTurtleGenericTunnelItem *&decrypted_item);
 
+    virtual uint64_t getCumulativeUpload(RsFileHash hash);
+    virtual uint64_t getCumulativeUploadAll();
+    virtual uint64_t getCumulativeUploadNum();
+
     /*************** Internal Transfer Fns *************************/
     virtual int tick();
 
@@ -421,6 +425,8 @@ private:
     std::map<RsFileHash,RsFileHash> mEncryptedHashes ; // This map is such that sha1(it->second) = it->first
     std::map<RsPeerId,RsFileHash> mEncryptedPeerIds ;  // This map holds the hash to be used with each peer id
     std::map<RsPeerId,std::map<RsFileHash,rstime_t> > mUploadLimitMap ;
+
+    std::map<RsFileHash,uint64_t> cumulative_uploaded;
 
 	/** Store search callbacks with timeout*/
     RS_DEPRECATED

--- a/src/retroshare/rsfiles.h
+++ b/src/retroshare/rsfiles.h
@@ -1212,5 +1212,9 @@ public:
 		virtual bool	ignoreDuplicates() = 0;
 		virtual void 	setIgnoreDuplicates(bool ignore) = 0;
 
+		virtual uint64_t getCumulativeUpload(RsFileHash hash) = 0;
+		virtual uint64_t getCumulativeUploadAll() = 0;
+		virtual uint64_t getCumulativeUploadNum() = 0;
+
 	virtual ~RsFiles() = default;
 };


### PR DESCRIPTION
- Added mutex, orginal work by @RetroPooh #107 
updated code to latest Master

Cyril wanted save feature someone need to implement this

> Another problem is that you're not saving the upload stats. So they are lost accross restarts, which somewhat kills the entire idea since upload stats are supposed to be long-term stats. But ftServer does not have a saving system.
> 
> All accounted for, it seems that it would make much more sense to store them with p3FileDatabase in ft_database.cfg.
> That means:
> 

> - add to p3FileDatabase class the functions to update the upload stats, as called from ftServer (no mutex needed in ftServer for that since the one is p3FileDatabase will be used)
> - create a new RsItem in rsfilelistitems.h to store the upload stats.
> - add the proper lines to load/save these stats in p3FileDatabase::loadList() and saveList() using these created items