### PR TITLE
refactor Streaming strategy to allow MP4 preview and rename legacy Streaming strategy to Sequential

### DIFF
--- a/src/ft/ftchunkmap.cc
+++ b/src/ft/ftchunkmap.cc
@@ -24,6 +24,10 @@
  * #define DEBUG_FTCHUNK 1
  *********/
 
+/********
+ * #define STREAMING_DEBUG 1
+ *********/
+
 #ifdef DEBUG_FTCHUNK
 #include <assert.h>
 #endif
@@ -610,7 +614,9 @@ uint32_t ChunkMap::getAvailableChunk(const RsPeerId& peer_id,bool& map_is_too_ol
                 {
                     if (i < _high_priority_chunks.size() && _high_priority_chunks[i])
                     {
+#ifdef STREAMING_DEBUG
                         RsDbg() << "STREAMING: ChunkMap::getAvailableChunk: PRIORITY returning chunk " << i << " for peer " << peer_id;
+#endif
                         return i;
                     }
                     else
@@ -735,7 +741,9 @@ void ChunkMap::buildPlainMap(uint64_t size, CompressedChunkMap& map)
 
 void ChunkMap::setHighPriorityRange(uint32_t startChunk, uint32_t endChunk)
 {
+#ifdef STREAMING_DEBUG
     RsDbg() << "STREAMING: ChunkMap::setHighPriorityRange " << startChunk << " -> " << endChunk;
+#endif
 
     if (_high_priority_chunks.size() != _map.size())
         _high_priority_chunks.resize(_map.size(), false);

--- a/src/ft/ftchunkmap.h
+++ b/src/ft/ftchunkmap.h
@@ -178,6 +178,9 @@ class ChunkMap
       virtual void getAvailabilityMap(CompressedChunkMap& cmap) const ;
 		void setAvailabilityMap(const CompressedChunkMap& cmap) ;
 
+		/// Sets a range of chunks to be downloaded with high priority (checked before strategy)
+		void setHighPriorityRange(uint32_t startChunk, uint32_t endChunk);
+
 		/// Removes the source availability map. The map
 		void removeFileSource(const RsPeerId& peer_id) ;
 
@@ -250,6 +253,7 @@ class ChunkMap
 		std::map<RsPeerId,Chunk>					   _active_chunks_feed ; 			//! vector of chunks being downloaded. Exactly 1 chunk per peer.
 		std::map<ChunkNumber,ChunkDownloadInfo>	_slices_to_download ; 			//! list of (slice offset,slice size) currently being downloaded
 		std::vector<FileChunksInfo::ChunkState>	_map ;								//! vector of chunk state over the whole file
+		std::vector<bool>                       _high_priority_chunks;          //! boolean mask for high priority chunks
 		std::map<RsPeerId,SourceChunksInfo>		_peers_chunks_availability ;	//! what does each source peer have
 		uint64_t												_total_downloaded ;				//! completion for the file
 		bool													_file_is_complete ;           //! set to true when the file is complete.

--- a/src/ft/ftcontroller.cc
+++ b/src/ft/ftcontroller.cc
@@ -1877,9 +1877,11 @@ bool ftController::saveList(bool &cleanup, std::list<RsItem *>& saveData)
 
 	switch(mDefaultChunkStrategy)
 	{
-		case FileChunksInfo::CHUNK_STRATEGY_STREAMING: 	configMap[default_chunk_strategy_ss] =  "STREAMING" ;
+		case FileChunksInfo::CHUNK_STRATEGY_SEQUENTIAL: 	configMap[default_chunk_strategy_ss] =  "SEQUENTIAL" ;
 																	  	break ;
 		case FileChunksInfo::CHUNK_STRATEGY_RANDOM:		configMap[default_chunk_strategy_ss] =  "RANDOM" ;
+																		break ;
+		case FileChunksInfo::CHUNK_STRATEGY_STREAMING: 	configMap[default_chunk_strategy_ss] =  "STREAMING" ;
 																		break ;
 
 		default:
@@ -2164,6 +2166,11 @@ bool  ftController::loadConfigMap(std::map<std::string, std::string> &configMap)
 		{
 			setDefaultChunkStrategy(FileChunksInfo::CHUNK_STRATEGY_STREAMING) ;
 			std::cerr << "Note: loading default value for chunk strategy: streaming" << std::endl;
+		}
+		else if(mit->second == "SEQUENTIAL")
+		{
+			setDefaultChunkStrategy(FileChunksInfo::CHUNK_STRATEGY_SEQUENTIAL) ;
+			std::cerr << "Note: loading default value for chunk strategy: sequential" << std::endl;
 		}
 		else if(mit->second == "RANDOM")
 		{

--- a/src/ft/ftfilecreator.cc
+++ b/src/ft/ftfilecreator.cc
@@ -24,6 +24,7 @@
 #include <cstdio>
 #include <sys/stat.h>
 #include "util/rsdebug.h"
+#include "util/rsendian.h"
 
 #include "ftfilecreator.h"
 #include "util/rstime.h"
@@ -811,12 +812,12 @@ bool ftFileCreator::checkForMp4Index()
         if (fseek(f, currentPos, SEEK_SET) != 0 || fread(&header, 1, 8, f) != 8)
             break;
 
-        uint32_t atomSize = be32toh(header.size);
+        uint32_t atomSize = rs_endian_fix(header.size);
         uint64_t realAtomSize = atomSize;
 
         if (atomSize == 1) {
              uint64_t bigSize;
-             if (fread(&bigSize, 1, 8, f) == 8) realAtomSize = be64toh(bigSize);
+             if (fread(&bigSize, 1, 8, f) == 8) realAtomSize = rs_endian_fix(bigSize);
         }
 
         // Create a null-terminated string for logging safely

--- a/src/ft/ftfilecreator.cc
+++ b/src/ft/ftfilecreator.cc
@@ -22,6 +22,7 @@
 
 #include <cerrno>
 #include <cstdio>
+#include <cstring>
 #include <sys/stat.h>
 #include "util/rsdebug.h"
 #include "util/rsendian.h"
@@ -48,6 +49,27 @@
 #define CHUNK_MAX_AGE           120
 #define MAX_FTCHUNKS_PER_PEER    40
 
+// MP4 Smart Preview. checkForMp4Index() is called from addFileData(), i.e. once per received
+// data block, and each call re-opens and re-walks the partial file. These two constants keep
+// that cost bounded: a file whose atom chain cannot be resolved is given up on for good.
+
+static const uint32_t MP4_ATOM_HEADER_SIZE     =  8 ;	//! size, then 4CC type
+static const uint32_t MP4_MAX_SCAN_ATTEMPTS    = 64 ;	//! fruitless walks before giving up
+
+//! Every ISO base media file starts with one of these boxes. Anything else is not an MP4,
+//! and no amount of additional data will turn it into one.
+
+static bool mp4LooksLikeIsoBmff(const char type[4])
+{
+	static const char * const known_boxes[] = { "ftyp","styp","moov","mdat","free","skip","wide","pnot","junk" } ;
+
+	for(uint32_t i=0;i<sizeof(known_boxes)/sizeof(known_boxes[0]);++i)
+		if(!strncmp(type,known_boxes[i],4))
+			return true ;
+
+	return false ;
+}
+
 /***********************************************************
 *
 *	ftFileCreator methods
@@ -55,7 +77,8 @@
 ***********************************************************/
 
 ftFileCreator::ftFileCreator(const std::string& path, uint64_t size, const RsFileHash& hash,bool assume_availability)
-	: ftFileProvider(path,size,hash), chunkMap(size,assume_availability), _mp4_index_found(false), _mp4_index_offset(0)
+	: ftFileProvider(path,size,hash), chunkMap(size,assume_availability), _mp4_index_found(false), _mp4_index_offset(0),
+	  _mp4_scan_abandoned(false), _mp4_scan_attempts(0)
 {
 #ifdef STREAMING_DEBUG
     RsDbg() << "STREAMING: ftFileCreator CONSTRUCTOR for " << path;
@@ -253,7 +276,7 @@ bool ftFileCreator::addFileData(uint64_t offset, uint32_t chunk_size, void *data
 #ifdef STREAMING_DEBUG
         RsDbg() << "STREAMING: addFileData offset=" << offset << " strat=" << chunkMap.getStrategy();
 #endif
-        if (!_mp4_index_found)
+        if (!_mp4_index_found && !_mp4_scan_abandoned)
         {
              checkForMp4Index();
         }
@@ -795,13 +818,32 @@ bool ftFileCreator::checkForMp4Index()
          return false;
     }
 
+    // Phase 2: Atom Parsing (Observer Mode)
+    if (_mp4_index_found) return true;
+
+    // The atom chain starts at offset 0. Until the head of the file has actually been
+    // received, reading it only returns the holes of the sparse partial file, so there is
+    // nothing to parse and no reason to touch the disk at all.
+
+    if (!chunkMap.isChunkAvailable(0, MP4_ATOM_HEADER_SIZE))
+        return false;
+
+    // We are called once per received data block and each walk re-opens the file, so bound
+    // the number of walks that end without a verdict.
+
+    if (++_mp4_scan_attempts > MP4_MAX_SCAN_ATTEMPTS)
+    {
+#ifdef STREAMING_DEBUG
+        RsDbg() << "STREAMING: giving up on the MP4 index of " << file_name << " after " << MP4_MAX_SCAN_ATTEMPTS << " scans";
+#endif
+        _mp4_scan_abandoned = true;
+        return false;
+    }
+
 #ifdef STREAMING_DEBUG
     // Phase 1: Just log that we passed the guard
     RsDbg() << "STREAMING: ftFileCreator::checkForMp4Index RUNNING. Strategy=" << strat << ". Parsing loop start.";
 #endif
-
-    // Phase 2: Atom Parsing (Observer Mode)
-    if (_mp4_index_found) return true;
 
     // Open file to read atoms
     FILE* f = fopen(file_name.c_str(), "rb");
@@ -825,8 +867,20 @@ bool ftFileCreator::checkForMp4Index()
 
     while (true)
     {
-        if (fseek(f, currentPos, SEEK_SET) != 0 || fread(&header, 1, 8, f) != 8)
+        if (fseek(f, currentPos, SEEK_SET) != 0 || fread(&header, 1, MP4_ATOM_HEADER_SIZE, f) != MP4_ATOM_HEADER_SIZE)
             break;
+
+        // A file that does not even begin with an ISO-BMFF box will never become one: stop
+        // here for good rather than coming back at every single block of the transfer.
+
+        if (currentPos == 0 && !mp4LooksLikeIsoBmff(header.type))
+        {
+#ifdef STREAMING_DEBUG
+            RsDbg() << "STREAMING: " << file_name << " is not an ISO base media file. No preview.";
+#endif
+            _mp4_scan_abandoned = true;
+            break;
+        }
 
         uint32_t atomSize = rs_endian_fix(header.size);
         uint64_t realAtomSize = atomSize;

--- a/src/ft/ftfilecreator.cc
+++ b/src/ft/ftfilecreator.cc
@@ -41,6 +41,10 @@
  * #define FILE_DEBUG 1
  ******/
 
+/*******
+ * #define STREAMING_DEBUG 1
+ ******/
+
 #define CHUNK_MAX_AGE           120
 #define MAX_FTCHUNKS_PER_PEER    40
 
@@ -53,7 +57,9 @@
 ftFileCreator::ftFileCreator(const std::string& path, uint64_t size, const RsFileHash& hash,bool assume_availability)
 	: ftFileProvider(path,size,hash), chunkMap(size,assume_availability), _mp4_index_found(false), _mp4_index_offset(0)
 {
+#ifdef STREAMING_DEBUG
     RsDbg() << "STREAMING: ftFileCreator CONSTRUCTOR for " << path;
+#endif
 	/* 
          * FIXME any inits to do?
          */
@@ -244,7 +250,9 @@ bool ftFileCreator::addFileData(uint64_t offset, uint32_t chunk_size, void *data
 		locked_notifyReceived(offset,chunk_size);
         
         // MP4 Smart Preview hook
+#ifdef STREAMING_DEBUG
         RsDbg() << "STREAMING: addFileData offset=" << offset << " strat=" << chunkMap.getStrategy();
+#endif
         if (!_mp4_index_found)
         {
              checkForMp4Index();
@@ -516,7 +524,9 @@ void ftFileCreator::setChunkStrategy(FileChunksInfo::ChunkStrategy s)
 #ifdef FILE_DEBUG
 	std::cerr << "ftFileCtreator: setting chunk strategy to " << s << std::endl ;
 #endif
+#ifdef STREAMING_DEBUG
     RsDbg() << "STREAMING: ftFileCreator::setChunkStrategy " << s;
+#endif
 	chunkMap.setStrategy(s) ;
 }
 
@@ -779,21 +789,27 @@ bool ftFileCreator::checkForMp4Index()
     // STRICT RULE: Only active in STREAMING_PRIO_END
     if (strat != FileChunksInfo::CHUNK_STRATEGY_STREAMING)
     {
-         // RsDbg() << "STREAMING: ftFileCreator::checkForMp4Index ignored. Strategy=" << strat;
+#ifdef STREAMING_DEBUG
+         RsDbg() << "STREAMING: ftFileCreator::checkForMp4Index ignored. Strategy=" << strat;
+#endif
          return false;
     }
 
+#ifdef STREAMING_DEBUG
     // Phase 1: Just log that we passed the guard
     RsDbg() << "STREAMING: ftFileCreator::checkForMp4Index RUNNING. Strategy=" << strat << ". Parsing loop start.";
-    
+#endif
+
     // Phase 2: Atom Parsing (Observer Mode)
     if (_mp4_index_found) return true;
 
     // Open file to read atoms
     FILE* f = fopen(file_name.c_str(), "rb");
-    if (!f) 
+    if (!f)
     {
+#ifdef STREAMING_DEBUG
         RsDbg() << "STREAMING: Failed to open file " << file_name;
+#endif
         return false;
     }
 
@@ -820,29 +836,37 @@ bool ftFileCreator::checkForMp4Index()
              if (fread(&bigSize, 1, 8, f) == 8) realAtomSize = rs_endian_fix(bigSize);
         }
 
+#ifdef STREAMING_DEBUG
         // Create a null-terminated string for logging safely
         char typeStr[5] = {0};
         memcpy(typeStr, header.type, 4);
 
         RsDbg() << "STREAMING: Found atom '" << typeStr << "' at " << currentPos << " size " << realAtomSize;
+#endif
 
         if (strncmp(header.type, "moov", 4) == 0) {
+#ifdef STREAMING_DEBUG
             RsDbg() << "STREAMING: MOOV atom found at " << currentPos << " (Beginning of file?). Stop.";
+#endif
             _mp4_index_found = true;
             break;
         }
 
         if (strncmp(header.type, "mdat", 4) == 0) {
             uint64_t predictedMoov = currentPos + realAtomSize;
+#ifdef STREAMING_DEBUG
             RsDbg() << "STREAMING: MDAT found. Size: " << realAtomSize << ". Predicted MOOV at: " << predictedMoov;
-            
+#endif
+
             // Phase 3: Actuation
             // Calculate chunks covering the MOOV index (from predictedMoov to end of file)
             uint32_t chunkSize = ChunkMap::CHUNKMAP_FIXED_CHUNK_SIZE; 
             uint32_t startChunk = predictedMoov / chunkSize;
             uint32_t endChunk   = mSize / chunkSize;
             
+#ifdef STREAMING_DEBUG
             RsDbg() << "STREAMING: Setting High Priority Range: " << startChunk << " -> " << endChunk;
+#endif
             chunkMap.setHighPriorityRange(startChunk, endChunk);
 
             _mp4_index_found = true; 
@@ -853,8 +877,10 @@ bool ftFileCreator::checkForMp4Index()
         if (realAtomSize == 0 || currentPos >= mSize) break; 
         
         if (++safe_loop_count > 50) {
+#ifdef STREAMING_DEBUG
              RsDbg() << "STREAMING: Safety break (too many atoms)";
-             break; 
+#endif
+             break;
         }
     }
 

--- a/src/ft/ftfilecreator.h
+++ b/src/ft/ftfilecreator.h
@@ -144,8 +144,14 @@ class ftFileCreator: public ftFileProvider
 
 		ChunkMap chunkMap ;
 
+
 		rstime_t _last_recv_time_t ;	/// last time stamp when data was received. Used for queue control.
 		rstime_t _creation_time ;		/// time at which the file creator was created. Used to spot long-inactive transfers.
+
+        // MP4 Smart Preview
+        bool _mp4_index_found;
+        uint64_t _mp4_index_offset;
+        bool checkForMp4Index();
 };
 
 #endif // FT_FILE_CREATOR_HEADER

--- a/src/ft/ftfilecreator.h
+++ b/src/ft/ftfilecreator.h
@@ -151,6 +151,8 @@ class ftFileCreator: public ftFileProvider
         // MP4 Smart Preview
         bool _mp4_index_found;
         uint64_t _mp4_index_offset;
+        bool _mp4_scan_abandoned;	/// the file is not a parseable MP4, or too many fruitless scans: stop looking
+        uint32_t _mp4_scan_attempts;	/// number of atom walks that ended without a conclusion
         bool checkForMp4Index();
 };
 

--- a/src/retroshare/rstypes.h
+++ b/src/retroshare/rstypes.h
@@ -353,9 +353,10 @@ struct FileChunksInfo : RsSerializable
 
 	enum ChunkStrategy : uint8_t
 	{
-		CHUNK_STRATEGY_STREAMING,
+		CHUNK_STRATEGY_SEQUENTIAL,
 		CHUNK_STRATEGY_RANDOM,
-		CHUNK_STRATEGY_PROGRESSIVE
+		CHUNK_STRATEGY_PROGRESSIVE,
+		CHUNK_STRATEGY_STREAMING
 	};
 
 	struct SliceInfo : RsSerializable

--- a/src/retroshare/rstypes.h
+++ b/src/retroshare/rstypes.h
@@ -354,9 +354,10 @@ struct FileChunksInfo : RsSerializable
 
 	enum ChunkStrategy : uint8_t
 	{
-		CHUNK_STRATEGY_STREAMING,
+		CHUNK_STRATEGY_SEQUENTIAL,
 		CHUNK_STRATEGY_RANDOM,
-		CHUNK_STRATEGY_PROGRESSIVE
+		CHUNK_STRATEGY_PROGRESSIVE,
+		CHUNK_STRATEGY_STREAMING
 	};
 
 	struct SliceInfo : RsSerializable


### PR DESCRIPTION
code and comment by Antigravity (under supervision)

Description
This PR introduces a proper "Smart Streaming" strategy for file transfers, designed to optimize MP4 video previewing, and cleans up the legacy naming confusion.

Key Changes:

Renamed Legacy Strategy: The old "Streaming" strategy (which was actually just downloading chunks 0, 1, 2...) has been correctly renamed to "Sequential". active everywhere (Settings, Context Menus, config files).

New "Streaming" Strategy: Implemented a new Smart Preview strategy. It behaves like Sequential (downloads from the start) but prioritizes MP4 index atoms (moov/cmov), which are often located at the end of the file. This allows video players to start playback immediately.

Windows Freeze Protection: Updated tooltips and warnings to inform users that both "Random" and "Streaming" strategies (which write to the end of the file) may cause temporary UI freezes on Windows during file allocation.

Modified files:

libretroshare/src/ft/ftcontroller.cc
: Migrated old "STREAMING" config values to the new "SEQUENTIAL" enum, while mapping the new Smart Streaming to its own ID.

libretroshare/src/retroshare/rstypes.h
: Added CHUNK_STRATEGY_STREAMING enum (id 3).

libretroshare/src/ft/ftchunkmap.cc/.h
: Implemented priority chunk logic for the new strategy.

libretroshare/src/ft/ftfilecreator.cc/.h
: Added MP4 atom parsing to detect and prioritize index chunks.
libretroshare/src/ft/ftcontroller.cc
: Updated save/load logic to handle new enum mapping and persistence strings.
GUI (retroshare-gui):

retroshare-gui/src/gui/FileTransfer/TransfersDialog.cpp/.h
: Updated context menus to include all 4 strategies (Sequential, Progressive, Random, Streaming).

retroshare-gui/src/gui/settings/TransferPage.cpp
: Handled settings persistence and Windows safety warnings.

retroshare-gui/src/gui/settings/TransferPage.ui
: Updated combo box items and tooltips with detailed explanations.
Web Interface (retroshare-webui):

retroshare-webui/webui-src/app/files/files_util.js
: Added the "Streaming" strategy to the JS mapping.
