### PR TITLE
fix: handle Windows drive root paths (C:/) in shared directories to prevent 0 files shown

### DIFF
--- a/src/file_sharing/directory_updater.cc
+++ b/src/file_sharing/directory_updater.cc
@@ -303,7 +303,7 @@ void LocalDirectoryUpdater::recursUpdateSharedDir(
 					if(dir_is_accepted && mFollowSymLinks && mIgnoreDuplicates)
 					{
 						std::string real_path = RsDirUtil::removeSymLinks(
-						            cumulated_path + "/" + dirIt.file_name() );
+						            RsDirUtil::makePath(cumulated_path, dirIt.file_name()) );
 
 						if( existing_directories.end() !=
 						        existing_directories.find(real_path) )
@@ -355,7 +355,7 @@ void LocalDirectoryUpdater::recursUpdateSharedDir(
 			 * The later is always needed. */
 
 			if( mHashCache->requestHash(
-			            cumulated_path + "/" + dit.name(),
+			            RsDirUtil::makePath(cumulated_path, dit.name()),
 			            dit.size(), dit.modtime(), hash, this, *dit ) )
 				mSharedDirectories->updateHash(*dit, hash, hash != dit.hash());
 		}
@@ -364,7 +364,7 @@ void LocalDirectoryUpdater::recursUpdateSharedDir(
 	// go through the list of sub-dirs and recursively update
 	for( DirectoryStorage::DirIterator stored_dir_it(mSharedDirectories, indx);
 	     stored_dir_it; ++stored_dir_it )
-		recursUpdateSharedDir( cumulated_path + "/" + stored_dir_it.name(),
+		recursUpdateSharedDir( RsDirUtil::makePath(cumulated_path, stored_dir_it.name()),
 		                       *stored_dir_it, existing_directories,
 		                       current_depth+1, some_files_not_ready );
 }

--- a/src/util/folderiterator.cc
+++ b/src/util/folderiterator.cc
@@ -137,7 +137,10 @@ bool FolderIterator::updateFileInfo(bool& should_skip)
 	  return true ;
    }
 
-   mFullPath = mFolderName + "/" + mFileName ;
+   if(!mFolderName.empty() && (mFolderName.back() == '/' || mFolderName.back() == '\\'))
+       mFullPath = mFolderName + mFileName ;
+   else
+       mFullPath = mFolderName + "/" + mFileName ;
 
 #warning cyril soler: should we take care of symbolic links on windows?
 #ifndef WINDOWS_SYS

--- a/src/util/folderiterator.cc
+++ b/src/util/folderiterator.cc
@@ -34,6 +34,8 @@
 #include "util/rswin.h"
 #endif
 
+#include "util/rsdir.h"
+
 
 //#define DEBUG_FOLDER_ITERATOR 1
 
@@ -137,10 +139,7 @@ bool FolderIterator::updateFileInfo(bool& should_skip)
 	  return true ;
    }
 
-   if(!mFolderName.empty() && (mFolderName.back() == '/' || mFolderName.back() == '\\'))
-       mFullPath = mFolderName + mFileName ;
-   else
-       mFullPath = mFolderName + "/" + mFileName ;
+   mFullPath = RsDirUtil::makePath(mFolderName, mFileName);
 
 #warning cyril soler: should we take care of symbolic links on windows?
 #ifndef WINDOWS_SYS

--- a/src/util/rsdir.cc
+++ b/src/util/rsdir.cc
@@ -527,6 +527,10 @@ bool RsDirUtil::checkDirectory(const std::string& dir)
 	// mingw64 _wstat fails when the directory name has trailing slash or backslash: we remove them
 	while (!fixed.empty() && (fixed.back() == '\\' || fixed.back() == '/'))
 		fixed.pop_back();
+	// Restore separator for Windows drive roots: "C:" alone means the
+	// current working directory on drive C, not the root of the drive.
+	if (fixed.size() == 2 && fixed[1] == ':' && isalpha(fixed[0]))
+		fixed += '\\';
 	librs::util::ConvertUtf8ToUtf16(fixed, wdir);
 	struct _stat buf;
 	val = _wstat(wdir.c_str(), &buf);


### PR DESCRIPTION
## Problem

On Windows, sharing a drive at its root level (e.g. [C:/] or [D:/]) results in RetroShare displaying 0 shared files. This is a regression introduced by the recent fix for `_wstat` failing on trailing slashes in [checkDirectory()]

## Root cause

Three interacting issues:

1. **[checkDirectory()]** — The trailing slash stripping turns [C:/] into [C:], which under Windows API (`_wstat`) refers to the *current working directory on drive C*, not the drive root. These are two fundamentally different concepts inherited from DOS.

2. **`FolderIterator::updateFileInfo()`** — The path construction `mFolderName + "/" + mFileName` produces double slashes (`C://file`) when iterating a drive root, causing `_wstati64` to fail silently on each entry.

3. **[recursUpdateSharedDir()]** — Same double-slash issue in 3 manual path concatenations (`cumulated_path + "/" + name`).

## Fix
- After stripping trailing slashes, restore `\` if the result is a bare drive letter ([C:] → `C:\`)
- Check if path already ends with a separator before adding one in `FolderIterator`
- Replace 3 manual concatenations with `RsDirUtil::makePath()` which already handles trailing separators correctly
