### PR TITLE
Implement edit and sticky posts features for Posted boards

### DIFF
--- a/src/libretroshare.pro
+++ b/src/libretroshare.pro
@@ -1193,6 +1193,8 @@ message("In rnp_rnplib precompilation code")
 
     win32-g++ {
         LIBRNP_OUTPUT_LIBRARY = librnp.dll.a
+        # mem.cpp uses strlen which requires <cstring>; force-include it for all librnp TUs
+        LIBRNP_CMAKE_CXXFLAGS *= -include cstring
     } else {
         LIBRNP_OUTPUT_LIBRARY = librnp.a
     }

--- a/src/retroshare/rsposted.h
+++ b/src/retroshare/rsposted.h
@@ -32,6 +32,7 @@
 #include "retroshare/rsgxscommon.h"
 #include "retroshare/rsgxscircles.h"
 #include "serialiser/rsserializable.h"
+#include "serialiser/rstlvidset.h"
 
 class RsPosted;
 
@@ -46,6 +47,11 @@ struct RsPostedGroup: public RsSerializable, RsGxsGenericGroupData
 	std::string mDescription;
 	RsGxsImage mGroupImage;
 
+	/** @brief List of board pinned posts, those are displayed on top
+	 * @todo run away from TLV old serializables as those types are opaque to
+	 * JSON API! */
+	RsTlvGxsMsgIdSet mPinnedPosts;
+
 	/// @see RsSerializable
 	virtual void serial_process( RsGenericSerializer::SerializeJob j,
 								 RsGenericSerializer::SerializeContext& ctx ) override
@@ -53,6 +59,11 @@ struct RsPostedGroup: public RsSerializable, RsGxsGenericGroupData
 		RS_SERIAL_PROCESS(mMeta);
 		RS_SERIAL_PROCESS(mDescription);
 		RS_SERIAL_PROCESS(mGroupImage);
+
+		if( mPinnedPosts.ids.empty() && j == RsGenericSerializer::DESERIALIZE
+		        && ctx.mOffset == ctx.mSize )
+			return;
+		RS_SERIAL_PROCESS(mPinnedPosts);
 	}
 };
 
@@ -280,7 +291,7 @@ public:
     virtual bool createPost(const RsPostedPost& post,RsGxsMessageId& post_id) =0;
 
     /**
-     * @brief createPostV2. Create post. Blocking API
+     * @brief createPostV2. Create or edit a post. Blocking API
      * @jsonapi{development}
      * @param[in] boardId        Id of the board where to post
      * @param[in] title          title of the post
@@ -290,6 +301,7 @@ public:
      * @param[in] image          optional post image.
      * @param[out] postId        id of the post after it's been generated
      * @param[out] error_message possible error message if the method returns false
+     * @param[in] origPostId     if non-empty, this post replaces the original post with this Id.
      * @return true if ok, false if an error occured (see error_message)
      */
     virtual bool createPostV2(const RsGxsGroupId& boardId,
@@ -299,7 +311,8 @@ public:
                       const RsGxsId& authorId,
                       const RsGxsImage& image,
                       RsGxsMessageId& postId,
-                      std::string& error_message) =0;
+                      std::string& error_message,
+                      const RsGxsMessageId& origPostId = RsGxsMessageId()) =0;
 
     /** @brief Add a comment on a post or on another comment. Blocking API.
      * @jsonapi{development}

--- a/src/rsitems/rsposteditems.cc
+++ b/src/rsitems/rsposteditems.cc
@@ -21,6 +21,7 @@
  *******************************************************************************/
 #include "rsitems/rsposteditems.h"
 #include "serialiser/rstypeserializer.h"
+#include "serialiser/rstlvbase.h"
 
 
 
@@ -45,14 +46,43 @@ void RsGxsPostedPostItem::serial_process(RsGenericSerializer::SerializeJob j,RsG
 void RsGxsPostedGroupItem::serial_process(RsGenericSerializer::SerializeJob j,RsGenericSerializer::SerializeContext& ctx)
 {
 	RsTypeSerializer::serial_process(j,ctx,TLV_TYPE_STR_DESCR ,mDescription,"mDescription") ;
-	
-	if(j == RsGenericSerializer::DESERIALIZE && ctx.mOffset == ctx.mSize)
-        return ;
 
-	if((j == RsGenericSerializer::SIZE_ESTIMATE || j == RsGenericSerializer::SERIALIZE) && mGroupImage.empty())
-		return ;
+	if(j == RsGenericSerializer::DESERIALIZE)
+	{
+		if(ctx.mOffset == ctx.mSize)
+			return;
 
-	RsTypeSerializer::serial_process<RsTlvItem>(j,ctx,mGroupImage,"mGroupImage") ;
+		if(ctx.mSize >= ctx.mOffset + TLV_HEADER_SIZE)
+		{
+			const uint16_t nextTlvType = GetTlvType(
+			            ctx.mData + ctx.mOffset );
+			if(nextTlvType == mGroupImage.TlvType())
+				RsTypeSerializer::serial_process<RsTlvItem>(
+				            j,ctx,mGroupImage,"mGroupImage" );
+		}
+
+		if(ctx.mOffset == ctx.mSize)
+			return;
+
+		if(ctx.mSize >= ctx.mOffset + TLV_HEADER_SIZE)
+		{
+			const uint16_t nextTlvType = GetTlvType(
+			            ctx.mData + ctx.mOffset );
+			if(nextTlvType == mPinnedPosts.TlvType())
+				RsTypeSerializer::serial_process<RsTlvItem>(
+				            j,ctx,mPinnedPosts,"mPinnedPosts" );
+		}
+		return;
+	}
+
+	if(!mGroupImage.empty())
+		RsTypeSerializer::serial_process<RsTlvItem>(j,ctx,mGroupImage,"mGroupImage") ;
+
+	if((j == RsGenericSerializer::SIZE_ESTIMATE
+	    || j == RsGenericSerializer::SERIALIZE)
+	        && mPinnedPosts.ids.empty()) return;
+
+	RsTypeSerializer::serial_process<RsTlvItem>(j,ctx,mPinnedPosts,"mPinnedPosts") ;
 }
 
 RsItem *RsGxsPostedSerialiser::create_item(uint16_t service_id,uint8_t item_subtype) const
@@ -119,6 +149,7 @@ void RsGxsPostedGroupItem::clear()
 {
 	mDescription.clear();
 	mGroupImage.TlvClear();
+	mPinnedPosts.TlvClear();
 }
 
 bool RsGxsPostedGroupItem::fromPostedGroup(RsPostedGroup &group, bool moveImage)
@@ -126,6 +157,7 @@ bool RsGxsPostedGroupItem::fromPostedGroup(RsPostedGroup &group, bool moveImage)
 	clear();
 	meta = group.mMeta;
 	mDescription = group.mDescription;
+	mPinnedPosts = group.mPinnedPosts;
 
 	if (moveImage)
 	{
@@ -144,6 +176,7 @@ bool RsGxsPostedGroupItem::toPostedGroup(RsPostedGroup &group, bool moveImage)
 {
 	group.mMeta = meta;
 	group.mDescription = mDescription;
+	group.mPinnedPosts = mPinnedPosts;
 	if (moveImage)
 	{
 		group.mGroupImage.take((uint8_t *) mGroupImage.binData.bin_data, mGroupImage.binData.bin_len);

--- a/src/rsitems/rsposteditems.cc
+++ b/src/rsitems/rsposteditems.cc
@@ -56,7 +56,7 @@ void RsGxsPostedGroupItem::serial_process(RsGenericSerializer::SerializeJob j,Rs
 		{
 			const uint16_t nextTlvType = GetTlvType(
 			            ctx.mData + ctx.mOffset );
-			if(nextTlvType == mGroupImage.TlvType())
+			if(nextTlvType == TLV_TYPE_IMAGE)
 				RsTypeSerializer::serial_process<RsTlvItem>(
 				            j,ctx,mGroupImage,"mGroupImage" );
 		}
@@ -68,7 +68,7 @@ void RsGxsPostedGroupItem::serial_process(RsGenericSerializer::SerializeJob j,Rs
 		{
 			const uint16_t nextTlvType = GetTlvType(
 			            ctx.mData + ctx.mOffset );
-			if(nextTlvType == mPinnedPosts.TlvType())
+			if(nextTlvType == TLV_TYPE_GXSMSGIDSET)
 				RsTypeSerializer::serial_process<RsTlvItem>(
 				            j,ctx,mPinnedPosts,"mPinnedPosts" );
 		}

--- a/src/rsitems/rsposteditems.h
+++ b/src/rsitems/rsposteditems.h
@@ -26,6 +26,7 @@
 #include "rsitems/rsgxscommentitems.h"
 #include "rsitems/rsgxsitems.h"
 #include "serialiser/rstlvimage.h"
+#include "serialiser/rstlvidset.h"
 
 #include "retroshare/rsposted.h"
 
@@ -48,6 +49,7 @@ public:
 	
 	std::string mDescription;
 	RsTlvImage mGroupImage;
+	RsTlvGxsMsgIdSet mPinnedPosts;
 
 };
 

--- a/src/services/p3posted.cc
+++ b/src/services/p3posted.cc
@@ -21,6 +21,7 @@
  *******************************************************************************/
 #include "services/p3posted.h"
 #include "retroshare/rsgxscircles.h"
+#include "retroshare/rsgxsflags.h"
 #include "retroshare/rspeers.h"
 #include "rsitems/rsposteditems.h"
 
@@ -730,7 +731,8 @@ bool p3Posted::createPostV2(const RsGxsGroupId& boardId,
                             const RsGxsId& authorId,
                             const RsGxsImage& image,
                             RsGxsMessageId& postId,
-                            std::string& error_message)
+                            std::string& error_message,
+                            const RsGxsMessageId& origPostId)
 {
     // check boardId
 
@@ -752,6 +754,36 @@ bool p3Posted::createPostV2(const RsGxsGroupId& boardId,
         return false;
     }
 
+    // If editing an existing post, validate it exists and the author matches (unless admin)
+
+    if(!origPostId.isNull())
+    {
+        std::vector<RsPostedPost> orig_posts;
+        std::vector<RsGxsComment> orig_comments;
+        std::vector<RsGxsVote>    orig_votes;
+
+        if(!getBoardContent(boardId, { origPostId }, orig_posts, orig_comments, orig_votes)
+                || orig_posts.size() != 1)
+        {
+            error_message = "Original post " + origPostId.toStdString() + " not found in board " + boardId.toStdString();
+            RsErr() << error_message;
+            return false;
+        }
+
+        const RsGxsId& origAuthor = orig_posts[0].mMeta.mAuthorId;
+        bool isAdmin = IS_GROUP_ADMIN(groupsInfo[0].mMeta.mSubscribeFlags);
+
+        if(origAuthor != authorId && !isAdmin)
+        {
+            error_message = "You do not have permission to edit this post. "
+                            "Only the post author or a board admin can edit posts.";
+            RsErr() << __PRETTY_FUNCTION__ << " Editor " << authorId
+                    << " is neither the original author " << origAuthor
+                    << " nor a board admin." << std::endl;
+            return false;
+        }
+    }
+
     RsPostedPost post;
     post.mMeta.mGroupId = boardId;
     post.mLink = link.toString();
@@ -759,6 +791,7 @@ bool p3Posted::createPostV2(const RsGxsGroupId& boardId,
     post.mNotes = notes;
     post.mMeta.mAuthorId = authorId;
     post.mMeta.mMsgName = title;
+    post.mMeta.mOrigMsgId = origPostId;
 
     // check size
 

--- a/src/services/p3posted.h
+++ b/src/services/p3posted.h
@@ -97,7 +97,8 @@ virtual void receiveHelperChanges(std::vector<RsGxsNotify*>& changes)
                       const RsGxsId& authorId,
                       const RsGxsImage& image,
                       RsGxsMessageId& postId,
-                      std::string& error_message) override;
+                      std::string& error_message,
+                      const RsGxsMessageId& origPostId = RsGxsMessageId()) override;
 
     bool voteForPost(const RsGxsGroupId& boardId,
                      const RsGxsMessageId& postMsgId,


### PR DESCRIPTION
This pull request introduces support for "pinned posts" in boards and adds the ability to edit posts (with proper permission checks) in the RetroShare Posted service. The main changes include updates to data structures and serialization logic to handle pinned posts, and enhancements to the post creation API to support editing with validation of author/admin rights.

**Pinned Posts Support:**

* Added a `mPinnedPosts` field of type `RsTlvGxsMsgIdSet` to `RsPostedGroup` and `RsGxsPostedGroupItem`, along with serialization/deserialization logic and necessary header includes. [[1]](diffhunk://#diff-a0d5e46a56b9d33d32868b5daf950d46811c64ad59ef6ebed766c14f45e08478R50-R66) [[2]](diffhunk://#diff-1643fe72e4588d3511ccb3d63b6b62bd8dc6fe48282c37a8d51eacff2bbe6b74L49-R85) [[3]](diffhunk://#diff-6776244ab0e2a782b08d5b809123a08f9a8e60c1a3a6d917fd6da00dc9bb2702R52)
* Updated the serialization and conversion functions in `rsitems/rsposteditems.cc` to handle the new `mPinnedPosts` field, ensuring it is properly cleared, copied, and serialized. [[1]](diffhunk://#diff-1643fe72e4588d3511ccb3d63b6b62bd8dc6fe48282c37a8d51eacff2bbe6b74L49-R85) [[2]](diffhunk://#diff-1643fe72e4588d3511ccb3d63b6b62bd8dc6fe48282c37a8d51eacff2bbe6b74R152-R160) [[3]](diffhunk://#diff-1643fe72e4588d3511ccb3d63b6b62bd8dc6fe48282c37a8d51eacff2bbe6b74R179)

**Post Editing Functionality:**

* Extended the `createPostV2` API to support editing existing posts by adding an optional `origPostId` parameter, updating all interface declarations and implementations accordingly. [[1]](diffhunk://#diff-a0d5e46a56b9d33d32868b5daf950d46811c64ad59ef6ebed766c14f45e08478R304) [[2]](diffhunk://#diff-a0d5e46a56b9d33d32868b5daf950d46811c64ad59ef6ebed766c14f45e08478L302-R315) [[3]](diffhunk://#diff-ff6ff9edf81ef289fbce628f6d98f93e245f91091608ff74c25d7721ac7dc724L733-R735) [[4]](diffhunk://#diff-c6173350eb82daacb14ccda989b242dcdb59bba0183481d8f7e6e6ee88ec7f33L100-R101)
* Implemented permission checks in `p3Posted::createPostV2` to ensure only the original author or a board admin can edit a post, with appropriate error handling and logging.

**Miscellaneous:**

* Added missing header includes to several files to support the new features and types. [[1]](diffhunk://#diff-a0d5e46a56b9d33d32868b5daf950d46811c64ad59ef6ebed766c14f45e08478R35) [[2]](diffhunk://#diff-1643fe72e4588d3511ccb3d63b6b62bd8dc6fe48282c37a8d51eacff2bbe6b74R24) [[3]](diffhunk://#diff-6776244ab0e2a782b08d5b809123a08f9a8e60c1a3a6d917fd6da00dc9bb2702R29) [[4]](diffhunk://#diff-ff6ff9edf81ef289fbce628f6d98f93e245f91091608ff74c25d7721ac7dc724R24)
* Updated Windows-specific build flags to force-include `<cstring>` for `librnp` to resolve a dependency.
- Related to RetroShare/RetroShare#1721