### PR TITLE
Fixed Use as direct source being automatically enabled when re-accepting a denied friend via Activity / Peer Details

### DIFF
--- a/src/pqi/p3peermgr.cc
+++ b/src/pqi/p3peermgr.cc
@@ -1069,7 +1069,14 @@ bool p3PeerMgrIMPL::addFriend(const RsPeerId& input_id, const RsPgpId& input_gpg
 		mLinkMgr->addFriend(id, vs_dht != RS_VS_DHT_OFF);
 	}
 
-	service_flags &= servicePermissionFlags(gpg_id) ; // Always reduce the permissions.
+	{
+		RS_STACK_MUTEX(mPeerMtx);
+		auto it = mFriendsPermissionFlags.find(gpg_id);
+		if(it != mFriendsPermissionFlags.end())
+		{
+			service_flags &= it->second; // Always reduce the permissions for existing friends.
+		}
+	}
 #ifdef RS_CHATSERVER //Defined by chatserver
 	setServicePermissionFlags(gpg_id,RS_NODE_PERM_NONE) ;
 #else

--- a/src/retroshare/rspeers.h
+++ b/src/retroshare/rspeers.h
@@ -98,7 +98,7 @@ const ServicePermissionFlags RS_NODE_PERM_NONE       ( 0x00000000 ) ;// 0x1, 0x2
 const ServicePermissionFlags RS_NODE_PERM_DIRECT_DL  ( 0x00000008 ) ;// Accept to directly DL from this peer (breaks anonymity)
 const ServicePermissionFlags RS_NODE_PERM_ALLOW_PUSH ( 0x00000010 ) ;// Auto-DL files recommended by this peer
 const ServicePermissionFlags RS_NODE_PERM_REQUIRE_WL ( 0x00000020 ) ;// Require white list clearance for connection
-const ServicePermissionFlags RS_NODE_PERM_DEFAULT    =  RS_NODE_PERM_DIRECT_DL ;
+const ServicePermissionFlags RS_NODE_PERM_DEFAULT    =  RS_NODE_PERM_NONE ;
 const ServicePermissionFlags RS_NODE_PERM_ALL        =  RS_NODE_PERM_DIRECT_DL | RS_NODE_PERM_ALLOW_PUSH | RS_NODE_PERM_REQUIRE_WL;
 
 // ...


### PR DESCRIPTION
Fxed Use as direct source being automatically enabled when re-accepting a denied friend via Activity / Peer Details

Changed Default: Updated RS_NODE_PERM_DEFAULT to NONE in rspeers.h. The option is now unchecked by default when re-accepting a friend.
Adjusted Logic: Updated addFriend in p3peermgr.cc to skip permission masking for new or re-added friends. This ensures the new global default doesn't block explicit flag settings during initial setup.
Result: The checkbox no longer auto-enables via the Activity Feed, while remaining correctly configurable in the connection wizard.