### PR TITLE
add pinned posts support to posted boards

### DIFF
--- a/src/retroshare/rsposted.h
+++ b/src/retroshare/rsposted.h
@@ -44,16 +44,18 @@ extern RsPosted* rsPosted;
 struct RsPostedGroup: public RsSerializable, RsGxsGenericGroupData
 {
 	std::string mDescription;
-	RsGxsImage mGroupImage;
+        RsGxsImage mGroupImage;
+        std::set<RsGxsMessageId> mPinnedPosts;  // pinned post ids
 
-	/// @see RsSerializable
-	virtual void serial_process( RsGenericSerializer::SerializeJob j,
-								 RsGenericSerializer::SerializeContext& ctx ) override
-	{
-		RS_SERIAL_PROCESS(mMeta);
-		RS_SERIAL_PROCESS(mDescription);
-		RS_SERIAL_PROCESS(mGroupImage);
-	}
+        /// @see RsSerializable
+        virtual void serial_process( RsGenericSerializer::SerializeJob j,
+                                                                 RsGenericSerializer::SerializeContext& ctx ) override
+        {
+                RS_SERIAL_PROCESS(mMeta);
+                RS_SERIAL_PROCESS(mDescription);
+                RS_SERIAL_PROCESS(mGroupImage);
+                RS_SERIAL_PROCESS(mPinnedPosts);
+        }
 };
 
 struct RsPostedPost: public RsSerializable, RsGxsGenericMsgData
@@ -435,6 +437,8 @@ public:
 
 	RS_DEPRECATED_FOR(editBoard)
 	virtual bool updateGroup(uint32_t &token, RsPostedGroup &group) = 0;
+
+	virtual bool pinPost(const RsGxsGroupId& boardId, const RsGxsMessageId& postId, bool pin) = 0;
 
 	virtual bool groupShareKeys(const RsGxsGroupId& group,const std::set<RsPeerId>& peers) = 0 ;
 

--- a/src/rsitems/rsposteditems.cc
+++ b/src/rsitems/rsposteditems.cc
@@ -45,6 +45,8 @@ void RsGxsPostedPostItem::serial_process(RsGenericSerializer::SerializeJob j,RsG
 void RsGxsPostedGroupItem::serial_process(RsGenericSerializer::SerializeJob j,RsGenericSerializer::SerializeContext& ctx)
 {
 	RsTypeSerializer::serial_process(j,ctx,TLV_TYPE_STR_DESCR ,mDescription,"mDescription") ;
+        RS_SERIAL_PROCESS(mPinnedPosts); 
+
 	
 	if(j == RsGenericSerializer::DESERIALIZE && ctx.mOffset == ctx.mSize)
         return ;

--- a/src/rsitems/rsposteditems.h
+++ b/src/rsitems/rsposteditems.h
@@ -47,6 +47,7 @@ public:
 	bool toPostedGroup(RsPostedGroup &group, bool moveImage);
 	
 	std::string mDescription;
+	std::set<RsGxsMessageId> mPinnedPosts;
 	RsTlvImage mGroupImage;
 
 };

--- a/src/services/p3posted.cc
+++ b/src/services/p3posted.cc
@@ -849,6 +849,7 @@ bool p3Posted::createCommentV2(
     cmt.mMeta.mParentId = parentId;
     cmt.mMeta.mAuthorId = authorId;
     cmt.mMeta.mOrigMsgId = origCommentId;
+
     cmt.mComment = comment;
 
     uint32_t token;
@@ -889,6 +890,23 @@ bool p3Posted::editBoard(RsPostedGroup& board)
 
 	return true;
 }
+
+bool p3Posted::pinPost(const RsGxsGroupId& boardId, const RsGxsMessageId& postId, bool pin)
+{
+    std::vector<RsPostedGroup> groupsInfo;
+    if(!getBoardsInfo({boardId}, groupsInfo) || groupsInfo.empty())
+        return false;
+
+    RsPostedGroup& grp = groupsInfo[0];
+
+    if(pin)
+        grp.mPinnedPosts.insert(postId);
+    else
+        grp.mPinnedPosts.erase(postId);
+
+    return editBoard(grp);
+}
+
 
 RsPosted::~RsPosted() = default;
 RsGxsPostedEvent::~RsGxsPostedEvent() = default;

--- a/src/services/p3posted.h
+++ b/src/services/p3posted.h
@@ -139,6 +139,7 @@ virtual void receiveHelperChanges(std::vector<RsGxsNotify*>& changes)
     virtual bool createPost(uint32_t &token, RsPostedPost &post) override;
 
     virtual bool updateGroup(uint32_t &token, RsPostedGroup &group) override;
+    bool pinPost(const RsGxsGroupId& boardId, const RsGxsMessageId& postId, bool pin) override;
     virtual bool groupShareKeys(const RsGxsGroupId &group, const std::set<RsPeerId>& peers) override;
 
     //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
adds pinned posts support to the posted boards service, mirrors the same 
pattern already used in forums (mPinnedPosts in rsgxsforums).

whats changed:
- mPinnedPosts field in RsPostedGroup struct in rsposteditems.h
- serialization wired up in RsGxsPostedGroupItem::serial_process
- pinPost() added to rsposted interface + implemented in p3posted

GUI side is in RetroShare/RetroShare#3206

ref: https://github.com/RetroShare/RetroShare/issues/2802