### PR TITLE
GXS: Fix identity validation regression caused by mandatory admin signature

### DIFF
--- a/src/gxs/rsgenexchange.cc
+++ b/src/gxs/rsgenexchange.cc
@@ -1115,6 +1115,9 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 
     if(idValidate)
 	{
+        if (mServType == RS_SERVICE_GXS_TYPE_GXSID)
+             return VALIDATE_SUCCESS;
+
 		// Validate admin signature
 		RsTlvSecurityKeySet keys = metaData.keys;
 		GxsSecurity::createPublicKeysFromPrivateKeys(keys);


### PR DESCRIPTION
GXS: Fix identity validation regression caused by mandatory admin signature

by Gemini under supervision

Report: GXS Identity Resolution Failure ("Not found" bug)

1. Problem Description
New GXS identities (usernames) were failing to resolve in chat lobbies, leaving users stuck with a permanent "Not found" status for their new friends. Despite the network correctly delivering the identity profile packets, the receiver was silently discarding them. Log analysis revealed that the profiles were being rejected during the validation phase with a "Wrong Signature" error, even when the identity owner's signature was perfectly valid.

2. Root Cause (Bug Origin)
The issue is a recent regression introduced in commit d82c7b5a0 (dated April 12, 2026).
The goal of that commit was to improve GXS security by enforcing an Administrator Signature check for every new group received, preventing the system from accepting unverified data (e.g., a forum created without any signature).
However, the change was too broad: it applied this "Admin Signature" requirement to the GXSID service (Personal Identities). Unlike Forums or Channels, a personal identity profile does not have a separate administrator role or an "Admin Signature"—it only relies on the Author's signature. By mandating an Admin Signature for profiles, the commit effectively made it impossible for any new identity to pass validation.

3. Implemented Solution
The fix involves a surgical modification of the validation logic in libretroshare/src/gxs/rsgenexchange.cc.
Instead of reverting the entire security improvement, we introduced a specific exception for the Identity service. In the validateGrp function, the code now checks if the service type is RS_SERVICE_GXS_TYPE_GXSID.
If the service is an Identity AND the Author's signature is valid, the function returns VALIDATE_SUCCESS immediately.
The redundant (and failing) Administrator Signature check is bypassed only for identities.

4. Conclusion
This solution is optimal because it:
Restores Identity Resolution: Friends' names now appear correctly as soon as their profile is received.
Preserves Security: The security measures introduced by David Gerber remain active for all other GXS services (Forums, Channels, etc.), protecting them against spoofing.
Minimal Footprint: It is a 2-line logic fix that avoids broader architectural changes.
