### PR TITLE
fix: add missing destructor in DirectoryStorage to free mFileHierarchy

### DIFF
--- a/src/file_sharing/directory_storage.cc
+++ b/src/file_sharing/directory_storage.cc
@@ -100,6 +100,11 @@ DirectoryStorage::DirectoryStorage(const RsPeerId &pid,const std::string& fname)
     load(fname) ;
 }
 
+DirectoryStorage::~DirectoryStorage()
+{
+	delete mFileHierarchy;
+}
+
 DirectoryStorage::EntryIndex DirectoryStorage::root() const
 {
     return EntryIndex(0) ;

--- a/src/file_sharing/directory_storage.h
+++ b/src/file_sharing/directory_storage.h
@@ -39,7 +39,7 @@ class DirectoryStorage
 {
 	public:
         DirectoryStorage(const RsPeerId& pid, const std::string& fname) ;
-        virtual ~DirectoryStorage() {}
+        virtual ~DirectoryStorage();
 
         typedef uint32_t EntryIndex ;
         static const EntryIndex NO_INDEX = 0xffffffff;


### PR DESCRIPTION
fix: add missing destructor in DirectoryStorage to free mFileHierarchy

