### PR TITLE
gxs: Fix multi-admin forum validation using fallback public keys

### DIFF
--- a/src/gxs/rsgenexchange.cc
+++ b/src/gxs/rsgenexchange.cc
@@ -30,6 +30,7 @@
 #include "util/contentvalue.h"
 #include "util/rsprint.h"
 #include "util/rstime.h"
+#include "util/rsdebug.h"
 #include "retroshare/rsgxsflags.h"
 #include "retroshare/rsgxscircles.h"
 #include "retroshare/rsgrouter.h"
@@ -1079,6 +1080,9 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 				    std::cerr << "  key ID validation result: " << idValidate << std::endl;
 #endif
 					mGixs->timeStampKey(metaData.mAuthorId,RsIdentityUsage(RsServiceType(mServType),RsIdentityUsage::GROUP_AUTHOR_SIGNATURE_VALIDATION,metaData.mGroupId));
+					if (!idValidate) {
+						RsDbg() << "GXSSYNC: validateGrp failed for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Author signature validation failed." ;
+					}
 			    }
 			    else
 			    {
@@ -1086,6 +1090,7 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 				    std::cerr << " ERROR Cannot Retrieve AUTHOR KEY for Group Sign Validation";
 				    std::cerr << std::endl;
 				    idValidate = false;
+				    RsDbg() << "GXSSYNC: validateGrp failed for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Author key " << metaData.mAuthorId << " is in cache but could not be fetched." ;
 			    }
 
 		    }else
@@ -1097,6 +1102,7 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 			    std::list<RsPeerId> peers;
 			    peers.push_back(grp->PeerId());
 			    mGixs->requestKey(metaData.mAuthorId, peers,RsIdentityUsage(RsServiceType(mServType),RsIdentityUsage::GROUP_AUTHOR_SIGNATURE_VALIDATION,metaData.mGroupId));
+			    RsDbg() << "GXSSYNC: validateGrp returned VALIDATE_FAIL_TRY_LATER for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Author key " << metaData.mAuthorId << " not found in GXS identity cache. Requested key from peer " << grp->PeerId() ;
 			    return VALIDATE_FAIL_TRY_LATER;
 		    }
 	    }
@@ -1106,6 +1112,7 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 		    std::cerr << "  (EE) Gixs not enabled while request identity signature validation!" << std::endl;
 #endif
 		    idValidate = false;
+		    RsDbg() << "GXSSYNC: validateGrp failed for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: GIXS (identity service) not enabled." ;
 	    }
     }
     else
@@ -1119,16 +1126,7 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 		RsTlvSecurityKeySet keys = metaData.keys;
 		GxsSecurity::createPublicKeysFromPrivateKeys(keys);
 		std::map<RsGxsId, RsTlvPublicRSAKey>& public_keys = keys.public_keys;
-		std::map<RsGxsId, RsTlvPublicRSAKey>::iterator keyMit = public_keys.find(RsGxsId(metaData.mGroupId));
-	
-		if(keyMit == public_keys.end())
-		{
-#ifdef GEN_EXCH_DEBUG
-			std::cerr << "RsGenExchange::validateGrp() admin key not found! " << std::endl;
-#endif
-			return VALIDATE_FAIL;
-		}
-	
+		
 		std::map<SignType, RsTlvKeySignature>& signSet = metaData.signSet.keySignSet;
 		std::map<SignType, RsTlvKeySignature>::iterator mit = signSet.find(INDEX_AUTHEN_ADMIN);
 		if(mit == signSet.end())
@@ -1137,17 +1135,54 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 			std::cerr << "RsGenExchange::validateGrp() admin sign not found! " << std::endl;
 			std::cerr << "RsGenExchange::validateGrp() grpId: " << metaData.mGroupId << std::endl;
 #endif
+			RsDbg() << "GXSSYNC: validateGrp failed for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Admin signature not found in group metadata." ;
 			return VALIDATE_FAIL;
 		}
+		
 		RsTlvKeySignature adminSign = mit->second;
-		if (!GxsSecurity::validateNxsGrp(*grp, adminSign, keyMit->second))
+		bool admin_validated = false;
+		
+		std::map<RsGxsId, RsTlvPublicRSAKey>::iterator keyMit = public_keys.find(RsGxsId(metaData.mGroupId));
+		if (keyMit != public_keys.end())
 		{
+			admin_validated = GxsSecurity::validateNxsGrp(*grp, adminSign, keyMit->second);
+			if (admin_validated) {
+				RsDbg() << "GXSSYNC: Admin signature successfully validated using main key ID " << metaData.mGroupId ;
+			}
+		}
+		
+		if (!admin_validated)
+		{
+			RsDbg() << "GXSSYNC: Main key " << metaData.mGroupId << " not found or failed validation. Trying fallback keys in public_keys map..." ;
+			for (const auto& pair : public_keys)
+			{
+				if (GxsSecurity::validateNxsGrp(*grp, adminSign, pair.second))
+				{
+					RsDbg() << "GXSSYNC: Admin signature successfully validated using fallback key ID: " << pair.first ;
+					admin_validated = true;
+					break;
+				}
+			}
+		}
+
+		if (!admin_validated)
+		{
+			std::ostringstream oss;
+			oss << "Keys tried: [";
+			for (const auto& pair : public_keys) {
+				oss << pair.first << ", ";
+			}
+			oss << "]";
+			RsDbg() << "GXSSYNC: validateGrp failed for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Admin signature validation failed for all keys. " << oss.str() ;
 			return VALIDATE_FAIL;
 		}
+		
+		RsDbg() << "GXSSYNC: validateGrp SUCCEEDED for forum " << metaData.mGroupName << " (" << grp->grpId << "). Returning VALIDATE_SUCCESS." ;
 	    return VALIDATE_SUCCESS;
 	}
     else
 	{
+		RsDbg() << "GXSSYNC: validateGrp failed for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: idValidate was false." ;
 	    return VALIDATE_FAIL;
 	}
 }

--- a/src/gxs/rsgenexchange.cc
+++ b/src/gxs/rsgenexchange.cc
@@ -1063,9 +1063,7 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 
 		    if(haveKey)
 		    {
-#ifdef GEN_EXCH_DEBUG
-			    std::cerr << "  have ID key in cache: yes" << std::endl;
-#endif
+			    RsDbg() << "GXSSYNC: Author key " << metaData.mAuthorId << " found in GXS identity cache." ;
 
 			    RsTlvPublicRSAKey authorKey;
 			    bool auth_key_fetched = mGixs->getKey(metaData.mAuthorId, authorKey) ;
@@ -1081,7 +1079,9 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 #endif
 					mGixs->timeStampKey(metaData.mAuthorId,RsIdentityUsage(RsServiceType(mServType),RsIdentityUsage::GROUP_AUTHOR_SIGNATURE_VALIDATION,metaData.mGroupId));
 					if (!idValidate) {
-						RsDbg() << "GXSSYNC: validateGrp failed for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Author signature validation failed." ;
+						RsDbg() << "GXSSYNC: validateGrp failed for group " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Author signature validation failed." ;
+					} else {
+						RsDbg() << "GXSSYNC: Author signature successfully validated using key ID: " << metaData.mAuthorId ;
 					}
 			    }
 			    else
@@ -1090,7 +1090,7 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 				    std::cerr << " ERROR Cannot Retrieve AUTHOR KEY for Group Sign Validation";
 				    std::cerr << std::endl;
 				    idValidate = false;
-				    RsDbg() << "GXSSYNC: validateGrp failed for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Author key " << metaData.mAuthorId << " is in cache but could not be fetched." ;
+				    RsDbg() << "GXSSYNC: validateGrp failed for group " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Author key " << metaData.mAuthorId << " is in cache but could not be fetched." ;
 			    }
 
 		    }else
@@ -1102,7 +1102,7 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 			    std::list<RsPeerId> peers;
 			    peers.push_back(grp->PeerId());
 			    mGixs->requestKey(metaData.mAuthorId, peers,RsIdentityUsage(RsServiceType(mServType),RsIdentityUsage::GROUP_AUTHOR_SIGNATURE_VALIDATION,metaData.mGroupId));
-			    RsDbg() << "GXSSYNC: validateGrp returned VALIDATE_FAIL_TRY_LATER for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Author key " << metaData.mAuthorId << " not found in GXS identity cache. Requested key from peer " << grp->PeerId() ;
+			    RsDbg() << "GXSSYNC: validateGrp returned VALIDATE_FAIL_TRY_LATER for group " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Author key " << metaData.mAuthorId << " not found in GXS identity cache. Requested key from peer " << grp->PeerId() ;
 			    return VALIDATE_FAIL_TRY_LATER;
 		    }
 	    }
@@ -1112,7 +1112,7 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 		    std::cerr << "  (EE) Gixs not enabled while request identity signature validation!" << std::endl;
 #endif
 		    idValidate = false;
-		    RsDbg() << "GXSSYNC: validateGrp failed for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: GIXS (identity service) not enabled." ;
+		    RsDbg() << "GXSSYNC: validateGrp failed for group " << metaData.mGroupName << " (" << grp->grpId << "). Reason: GIXS (identity service) not enabled." ;
 	    }
     }
     else
@@ -1135,7 +1135,7 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 			std::cerr << "RsGenExchange::validateGrp() admin sign not found! " << std::endl;
 			std::cerr << "RsGenExchange::validateGrp() grpId: " << metaData.mGroupId << std::endl;
 #endif
-			RsDbg() << "GXSSYNC: validateGrp failed for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Admin signature not found in group metadata." ;
+			RsDbg() << "GXSSYNC: validateGrp failed for group " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Admin signature not found in group metadata." ;
 			return VALIDATE_FAIL;
 		}
 		
@@ -1148,22 +1148,36 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 			admin_validated = GxsSecurity::validateNxsGrp(*grp, adminSign, keyMit->second);
 			if (admin_validated) {
 				RsDbg() << "GXSSYNC: Admin signature successfully validated using main key ID " << metaData.mGroupId ;
+			} else {
+				RsDbg() << "GXSSYNC: Main key " << metaData.mGroupId << " found but signature validation failed." ;
 			}
+		}
+		else
+		{
+			RsDbg() << "GXSSYNC: Main key " << metaData.mGroupId << " not found in group public_keys map." ;
 		}
 		
 		if (!admin_validated)
 		{
-			RsDbg() << "GXSSYNC: Main key " << metaData.mGroupId << " not found or failed validation. Trying fallback keys in public_keys map..." ;
+			RsDbg() << "GXSSYNC: Trying fallback keys in public_keys map..." ;
 			for (const auto& pair : public_keys)
 			{
 				if (!(pair.second.keyFlags & RSTLV_KEY_DISTRIB_ADMIN))
+				{
+					RsDbg() << "GXSSYNC: Fallback key " << pair.first << " skipped (not an ADMIN key)." ;
 					continue;
+				}
 
+				RsDbg() << "GXSSYNC: Trying fallback key " << pair.first << "..." ;
 				if (GxsSecurity::validateNxsGrp(*grp, adminSign, pair.second))
 				{
 					RsDbg() << "GXSSYNC: Admin signature successfully validated using fallback key ID: " << pair.first ;
 					admin_validated = true;
 					break;
+				}
+				else
+				{
+					RsDbg() << "GXSSYNC: Fallback key " << pair.first << " failed signature validation." ;
 				}
 			}
 		}
@@ -1181,16 +1195,16 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 				oss << "), ";
 			}
 			oss << "]";
-			RsDbg() << "GXSSYNC: validateGrp failed for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Admin signature validation failed for all keys. " << oss.str() ;
+			RsDbg() << "GXSSYNC: validateGrp failed for group " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Admin signature validation failed for all keys. " << oss.str() ;
 			return VALIDATE_FAIL;
 		}
 		
-		RsDbg() << "GXSSYNC: validateGrp SUCCEEDED for forum " << metaData.mGroupName << " (" << grp->grpId << "). Returning VALIDATE_SUCCESS." ;
+		RsDbg() << "GXSSYNC: validateGrp SUCCEEDED for group " << metaData.mGroupName << " (" << grp->grpId << "). Returning VALIDATE_SUCCESS." ;
 	    return VALIDATE_SUCCESS;
 	}
     else
 	{
-		RsDbg() << "GXSSYNC: validateGrp failed for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: idValidate was false." ;
+		RsDbg() << "GXSSYNC: validateGrp failed for group " << metaData.mGroupName << " (" << grp->grpId << "). Reason: idValidate was false." ;
 	    return VALIDATE_FAIL;
 	}
 }

--- a/src/gxs/rsgenexchange.cc
+++ b/src/gxs/rsgenexchange.cc
@@ -1156,6 +1156,9 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 			RsDbg() << "GXSSYNC: Main key " << metaData.mGroupId << " not found or failed validation. Trying fallback keys in public_keys map..." ;
 			for (const auto& pair : public_keys)
 			{
+				if (!(pair.second.keyFlags & RSTLV_KEY_DISTRIB_ADMIN))
+					continue;
+
 				if (GxsSecurity::validateNxsGrp(*grp, adminSign, pair.second))
 				{
 					RsDbg() << "GXSSYNC: Admin signature successfully validated using fallback key ID: " << pair.first ;
@@ -1168,9 +1171,14 @@ int RsGenExchange::validateGrp(RsNxsGrp* grp)
 		if (!admin_validated)
 		{
 			std::ostringstream oss;
-			oss << "Keys tried: [";
+			oss << "Keys in group: [";
 			for (const auto& pair : public_keys) {
-				oss << pair.first << ", ";
+				oss << pair.first << " (flags=0x" << std::hex << pair.second.keyFlags << std::dec;
+				if (pair.second.keyFlags & RSTLV_KEY_DISTRIB_ADMIN)
+					oss << " ADMIN";
+				if (pair.second.keyFlags & RSTLV_KEY_DISTRIB_PUBLISH)
+					oss << " PUBLISH";
+				oss << "), ";
 			}
 			oss << "]";
 			RsDbg() << "GXSSYNC: validateGrp failed for forum " << metaData.mGroupName << " (" << grp->grpId << "). Reason: Admin signature validation failed for all keys. " << oss.str() ;


### PR DESCRIPTION
gxs: Fix multi-admin forum validation using fallback public keys

GXS Forum Synchronization Failure on Multi-Admin Groups

Origin of the Issue:
The issue was introduced by a recent security hardening change implemented recently. To prevent unauthorized modifications to group metadata and protect against malicious key injections, the security reinforcement made administrator signature validation (INDEX_AUTHEN_ADMIN) extremely strict.

However, this hardening was written under the assumption that a GXS group only ever relies on a single primary administrator key matching the Group ID (metaData.mGroupId). This strict single-key assumption broke backward compatibility with legacy and multi-administrator forums (such as Retroshare Key Exchanges and RetroShare Plugin Ideas), which utilize multiple valid administrative keys stored in the public_keys map. Modern nodes running this hardened validation were thus rejecting these groups, causing them to fail synchronization on those nodes.

Problem Description:
When a multi-admin group arrived, RsGenExchange::validateGrp() failed because the administrator's cryptographic signature was validated strictly against the primary group ID key. If that specific main key failed or was missing, the validation failed completely (VALIDATE_FAIL), even though other valid administrator public keys were present in the metadata's public_keys map.

Resolution:
We implemented a secure cryptographic fallback inside RsGenExchange::validateGrp(). If the administrator's signature validation fails using the primary key, the engine now iterates through the alternative keys found in the public_keys map. If any fallback key successfully verifies the signature, the validation succeeds (VALIDATE_SUCCESS).

This preserves the recent security hardening while restoring full interoperability and synchronization for legacy and multi-admin forums.