### PR TITLE
fix wrong static declaration in pqithreadstreamer.cc

### DIFF
--- a/src/pqi/pqithreadstreamer.cc
+++ b/src/pqi/pqithreadstreamer.cc
@@ -70,8 +70,6 @@ int	pqithreadstreamer::tick()
 
 void pqithreadstreamer::threadTick()
 {
-        static uint32_t recv_timeout = mTimeout;
-        static uint32_t sleep_period = mSleepPeriod;
         uint32_t readbytes = 0;
         uint32_t sentbytes = 0;
 	bool isactive = false;
@@ -95,7 +93,7 @@ void pqithreadstreamer::threadTick()
 	// Fill incoming queue
 	{
 		RsStackMutex stack(mThreadMutex);
-		readbytes = tick_recv(recv_timeout);
+		readbytes = tick_recv(mTimeout);
 	}
 
 	// Process incoming items, move them to relevant service queue or shortcut to fast service
@@ -117,22 +115,22 @@ void pqithreadstreamer::threadTick()
         {
                 // Activity detected: switch to maximum reactivity immediately
                 // This ensure fast throughput for data bursts
-                recv_timeout = STREAMER_TIMEOUT_MIN;
-                sleep_period = STREAMER_SLEEP_MIN;
+                mTimeout = STREAMER_TIMEOUT_MIN;
+                mSleepPeriod = STREAMER_SLEEP_MIN;
         }
         else
         {
                 // No activity: gradually increase the timeout and sleep to save CPU cycles
-                if (recv_timeout < STREAMER_TIMEOUT_MAX)
-                        recv_timeout += STREAMER_TIMEOUT_DELTA;
-                if (sleep_period < STREAMER_SLEEP_MAX)
-                        sleep_period += STREAMER_SLEEP_DELTA;
+                if (mTimeout < STREAMER_TIMEOUT_MAX)
+                        mTimeout += STREAMER_TIMEOUT_DELTA;
+                if (mSleepPeriod < STREAMER_SLEEP_MAX)
+                        mSleepPeriod += STREAMER_SLEEP_DELTA;
         }
 
-//	RsDbg() << "PQISTREAMER pqithreadstreamer::threadTick() recv_timeout " << std::dec << recv_timeout / 1000 << " sleep_period " <<  sleep_period / 1000 << " readbytes " << readbytes << "  sentbytes " << sentbytes;
+	// RsDbg() << "PQISTREAMER " << threadName() << " pqithreadstreamer::threadTick() mTimeout " << std::dec << mTimeout / 1000 << " mSleepPeriod " <<  mSleepPeriod / 1000 << " readbytes " << readbytes << "  sentbytes " << sentbytes;
 
-	if (sleep_period > 0)
+	if (mSleepPeriod > 0)
 	{
-		rstime::rs_usleep(sleep_period);
+		rstime::rs_usleep(mSleepPeriod);
 	}
 }


### PR DESCRIPTION
fix wrong static declaration in pqithreadstreamer.cc

This branch fixed a critical bug in the pqithreadstreamer class related to how thread sleep and timeout periods were managed.

The Problem
In the original code, the variables recv_timeout and sleep_period inside the threadTick() function were declared as static:
This bug was introduced by me (jolavillette) in 
commit 2e2bcb8ac0eacd8f35435cd5cb76ac5ee2059bfd
Author: jolavillette <jolavillette@gmail.com>
Date:   Fri Jan 2 22:17:30 2026 +0100
    use adaptive timeout and sleep in pqithreadstreamer

cpp
static uint32_t recv_timeout = mTimeout;
static uint32_t sleep_period = mSleepPeriod;
In C++, a static variable inside a function is shared across all instances of that class. Since pqithreadstreamer is instantiated for every single peer connection (e.g., if you have 50 friends online, you have 50 instances), they were all fighting over the same two variables.

This created several issues:
- Cross-connection interference: Activity on one peer connection would reset the "global" timeout/sleep for all other connections.
Incorrect adaptation: The adaptive logic (which reduces sleep when there is data and increases it when idle) couldn't work properly because it was being updated by multiple threads simultaneously without coordination.
- Performance & CPU usage: Idle connections might not sleep enough if another connection was busy, leading to unnecessary CPU consumption.

The Fix
The branch removed the static keywords and used instance member variables (mTimeout and mSleepPeriod) instead.

Now, each peer connection has its own independent timing state. This ensures that:
- Adaptive timing works correctly for each individual connection.
- Idle connections sleep properly to save CPU, regardless of what other peers are doing.
- Data races and state pollution between peer threads are eliminated.