### PR TITLE
Add pinned posts support to boards

### DIFF
--- a/src/retroshare/rsposted.h
+++ b/src/retroshare/rsposted.h
@@ -32,6 +32,8 @@
 #include "retroshare/rsgxscommon.h"
 #include "retroshare/rsgxscircles.h"
 #include "serialiser/rsserializable.h"
+#include "serialiser/rstlvidset.h"
+#include "serialiser/rstypeserializer.h"
 
 class RsPosted;
 
@@ -45,6 +47,7 @@ struct RsPostedGroup: public RsSerializable, RsGxsGenericGroupData
 {
 	std::string mDescription;
 	RsGxsImage mGroupImage;
+	RsTlvGxsMsgIdSet mPinnedPosts;
 
 	/// @see RsSerializable
 	virtual void serial_process( RsGenericSerializer::SerializeJob j,
@@ -53,13 +56,23 @@ struct RsPostedGroup: public RsSerializable, RsGxsGenericGroupData
 		RS_SERIAL_PROCESS(mMeta);
 		RS_SERIAL_PROCESS(mDescription);
 		RS_SERIAL_PROCESS(mGroupImage);
+
+		switch(j)
+		{
+		case RsGenericSerializer::TO_JSON: // fallthrough
+		case RsGenericSerializer::FROM_JSON:
+			RsTypeSerializer::serial_process(j, ctx, mPinnedPosts.ids, "mPinnedPosts");
+			break;
+		default:
+			RS_SERIAL_PROCESS(mPinnedPosts);
+		}
 	}
 };
 
 struct RsPostedPost: public RsSerializable, RsGxsGenericMsgData
 {
 	RsPostedPost(): mHaveVoted(false), mUpVotes(0), mDownVotes(0), mComments(0),
-	    mHotScore(0), mTopScore(0), mNewScore(0) {}
+	    mHotScore(0), mTopScore(0), mNewScore(0), mPinned(false) {}
 
 	bool calculateScores(rstime_t ref_time);
 
@@ -78,6 +91,7 @@ struct RsPostedPost: public RsSerializable, RsGxsGenericMsgData
 	double  mHotScore;
 	double  mTopScore;
 	double  mNewScore;
+	bool    mPinned;
 
 	RsGxsImage mImage;
 
@@ -96,6 +110,7 @@ struct RsPostedPost: public RsSerializable, RsGxsGenericMsgData
 		RS_SERIAL_PROCESS(mHotScore);
 		RS_SERIAL_PROCESS(mTopScore);
 		RS_SERIAL_PROCESS(mNewScore);
+		RS_SERIAL_PROCESS(mPinned);
 	}
 };
 
@@ -131,6 +146,7 @@ enum class RsPostedEventCode: uint8_t
 	NEW_COMMENT              = 0x0a,
 	NEW_VOTE                 = 0x0b,
 	BOARD_DELETED            = 0x0c,
+	PINNED_POSTS_CHANGED     = 0x0d,
 };
 
 
@@ -239,6 +255,21 @@ public:
 	 * @return false on error, true otherwise
 	 */
 	virtual bool editBoard(RsPostedGroup& board) =0;
+
+	/**
+	 * @brief Pin or unpin a board post.
+	 * @jsonapi{development}
+	 * @param[in] boardId id of the board containing the post
+	 * @param[in] postId id of the post to pin or unpin
+	 * @param[in] pinned true to pin, false to unpin
+	 * @param[out] errorMessage possible error message if the method returns false
+	 * @return false on error, true otherwise
+	 */
+	virtual bool setPostPinned(
+	        const RsGxsGroupId& boardId,
+	        const RsGxsMessageId& postId,
+	        bool pinned,
+	        std::string& errorMessage ) = 0;
 
 	/**
 	 * @brief Create board. Blocking API.

--- a/src/rsitems/rsposteditems.cc
+++ b/src/rsitems/rsposteditems.cc
@@ -45,14 +45,22 @@ void RsGxsPostedPostItem::serial_process(RsGenericSerializer::SerializeJob j,RsG
 void RsGxsPostedGroupItem::serial_process(RsGenericSerializer::SerializeJob j,RsGenericSerializer::SerializeContext& ctx)
 {
 	RsTypeSerializer::serial_process(j,ctx,TLV_TYPE_STR_DESCR ,mDescription,"mDescription") ;
-	
+
 	if(j == RsGenericSerializer::DESERIALIZE && ctx.mOffset == ctx.mSize)
         return ;
 
-	if((j == RsGenericSerializer::SIZE_ESTIMATE || j == RsGenericSerializer::SERIALIZE) && mGroupImage.empty())
+	if((j == RsGenericSerializer::SIZE_ESTIMATE || j == RsGenericSerializer::SERIALIZE) && mGroupImage.empty() && mPinnedPosts.ids.empty())
 		return ;
 
 	RsTypeSerializer::serial_process<RsTlvItem>(j,ctx,mGroupImage,"mGroupImage") ;
+
+	if(j == RsGenericSerializer::DESERIALIZE && ctx.mOffset == ctx.mSize)
+		return ;
+
+	if((j == RsGenericSerializer::SIZE_ESTIMATE || j == RsGenericSerializer::SERIALIZE) && mPinnedPosts.ids.empty())
+		return ;
+
+	RsTypeSerializer::serial_process<RsTlvItem>(j,ctx,mPinnedPosts,"mPinnedPosts") ;
 }
 
 RsItem *RsGxsPostedSerialiser::create_item(uint16_t service_id,uint8_t item_subtype) const
@@ -118,6 +126,7 @@ void RsGxsPostedPostItem::clear()
 void RsGxsPostedGroupItem::clear()
 {
 	mDescription.clear();
+	mPinnedPosts.TlvClear();
 	mGroupImage.TlvClear();
 }
 
@@ -126,6 +135,7 @@ bool RsGxsPostedGroupItem::fromPostedGroup(RsPostedGroup &group, bool moveImage)
 	clear();
 	meta = group.mMeta;
 	mDescription = group.mDescription;
+	mPinnedPosts = group.mPinnedPosts;
 
 	if (moveImage)
 	{
@@ -144,6 +154,8 @@ bool RsGxsPostedGroupItem::toPostedGroup(RsPostedGroup &group, bool moveImage)
 {
 	group.mMeta = meta;
 	group.mDescription = mDescription;
+	group.mPinnedPosts = mPinnedPosts;
+
 	if (moveImage)
 	{
 		group.mGroupImage.take((uint8_t *) mGroupImage.binData.bin_data, mGroupImage.binData.bin_len);

--- a/src/rsitems/rsposteditems.h
+++ b/src/rsitems/rsposteditems.h
@@ -26,6 +26,7 @@
 #include "rsitems/rsgxscommentitems.h"
 #include "rsitems/rsgxsitems.h"
 #include "serialiser/rstlvimage.h"
+#include "serialiser/rstlvidset.h"
 
 #include "retroshare/rsposted.h"
 
@@ -48,6 +49,7 @@ public:
 	
 	std::string mDescription;
 	RsTlvImage mGroupImage;
+	RsTlvGxsMsgIdSet mPinnedPosts;
 
 };
 

--- a/src/services/p3posted.cc
+++ b/src/services/p3posted.cc
@@ -890,5 +890,41 @@ bool p3Posted::editBoard(RsPostedGroup& board)
 	return true;
 }
 
+bool p3Posted::setPostPinned(
+        const RsGxsGroupId& boardId,
+        const RsGxsMessageId& postId,
+        bool pinned,
+        std::string& errorMessage )
+{
+	const auto failure = [&](const std::string& err)
+	{
+		errorMessage = err;
+		RsErr() << __PRETTY_FUNCTION__ << " " << err << std::endl;
+		return false;
+	};
+
+	std::vector<RsPostedGroup> groupsInfo;
+	if(!getBoardsInfo({ boardId }, groupsInfo) || groupsInfo.size() != 1)
+		return failure("Board with Id " + boardId.toStdString() + " does not exist.");
+
+	std::vector<RsPostedPost> posts;
+	std::vector<RsGxsComment> comments;
+	std::vector<RsGxsVote> votes;
+
+	if(!getBoardContent(boardId, { postId }, posts, comments, votes) || posts.size() != 1)
+		return failure(
+		        "Post with Id " + postId.toStdString() + " does not exist in board "
+		        + boardId.toStdString() + ".");
+
+	RsPostedGroup board = groupsInfo.front();
+
+	if(pinned)
+		board.mPinnedPosts.ids.insert(postId);
+	else
+		board.mPinnedPosts.ids.erase(postId);
+
+	return editBoard(board);
+}
+
 RsPosted::~RsPosted() = default;
 RsGxsPostedEvent::~RsGxsPostedEvent() = default;

--- a/src/services/p3posted.h
+++ b/src/services/p3posted.h
@@ -77,6 +77,12 @@ virtual void receiveHelperChanges(std::vector<RsGxsNotify*>& changes)
 
 	bool editBoard(RsPostedGroup& board) override;
 
+	bool setPostPinned(
+	        const RsGxsGroupId& boardId,
+	        const RsGxsMessageId& postId,
+	        bool pinned,
+	        std::string& errorMessage ) override;
+
 	bool createBoard(RsPostedGroup& board) override;
 
     bool createBoardV2(const std::string& board_name,


### PR DESCRIPTION
## Summary
- add a pinned post ID set to board group data
- expose setPostPinned() on RsPosted/p3Posted
- validate the target board and post before updating the board pin set

This is the library/API side for board post pinning in the RetroShare Posted GUI.

## Validation
- git diff --check
- local compile not run: qmake, make, g++, and cl are not installed in this workspace