### PR TITLE
fix(mail): avoid unconditional periodic saves of email database

### DIFF
--- a/src/services/p3msgservice.cc
+++ b/src/services/p3msgservice.cc
@@ -526,7 +526,7 @@ int p3MsgService::checkOutgoingMessages()
 
     if(changed)
     {
-        RsDbg() << "MAIL: checkOutgoingMessages() triggering IndicateConfigChanged(SAVE_NOW)" << std::endl;
+        // RsDbg() << "MAIL: checkOutgoingMessages() triggering IndicateConfigChanged(SAVE_NOW)" << std::endl;
         IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);
     }
 

--- a/src/services/p3msgservice.cc
+++ b/src/services/p3msgservice.cc
@@ -395,6 +395,7 @@ void p3MsgService::checkSizeAndSendMessage(RsMsgItem *msg,const RsPeerId& destin
 
 int p3MsgService::checkOutgoingMessages()
 {
+    bool changed = false;
     auto pEvent = std::make_shared<RsMailStatusEvent>();
     pEvent->mMailStatusEventCode = RsMailStatusEventCode::MESSAGE_SENT;
 
@@ -421,6 +422,7 @@ int p3MsgService::checkOutgoingMessages()
                 ++tmp;
                 msgOutgoing.erase(mit);
                 mit = tmp;
+                changed = true;
 
                 continue;
             }
@@ -454,6 +456,7 @@ int p3MsgService::checkOutgoingMessages()
                         ++tmp;
                         mit->second.erase(fit);
                         fit = tmp;
+                        changed = true;
 
                         continue;
                     }
@@ -470,6 +473,7 @@ int p3MsgService::checkOutgoingMessages()
                 {
                     minfo.flags |= RS_MSG_FLAGS_ROUTED;
                     minfo.flags |= RS_MSG_FLAGS_DISTANT;
+                    changed = true;
 
 #ifdef DEBUG_DISTANT_MSG
                     RsDbg() << "Message id " << mit->first << " is distant: kept in outgoing, and marked as ROUTED" << std::endl;
@@ -491,6 +495,7 @@ int p3MsgService::checkOutgoingMessages()
                         ++tmp;
                         mit->second.erase(fit);
                         fit = tmp;
+                        changed = true;
                         continue;
                     }
                     else
@@ -509,6 +514,7 @@ int p3MsgService::checkOutgoingMessages()
                 ++tmp;
                 msgOutgoing.erase(mit);
                 mit=tmp;
+                changed = true;
             }
             else
                 ++mit;
@@ -518,7 +524,11 @@ int p3MsgService::checkOutgoingMessages()
     if(rsEvents && !pEvent->mChangedMsgIds.empty())
         rsEvents->postEvent(pEvent);
 
-    IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);
+    if(changed)
+    {
+        RsDbg() << "MAIL: checkOutgoingMessages() triggering IndicateConfigChanged(SAVE_NOW)" << std::endl;
+        IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);
+    }
 
     return 0;
 }


### PR DESCRIPTION
fix(mail): avoid unconditional periodic saves of email database

Problem Description
The periodic method p3MsgService::checkOutgoingMessages() is executed automatically every 5 seconds (via the service's tick() routine). A performance bug was originally introduced by libretroshare commit f2724f97 ("fix: save config after sending node-to-node msgs to avoid resending"). That commit aimed to prevent node-to-node messages from being sent repeatedly by forcing a configuration save immediately after they were transmitted. However, by adding the call to IndicateConfigChanged(SAVE_NOW) unconditionally at the end of checkOutgoingMessages(), it caused the function to trigger a disk write every 5 seconds, even when the outgoing queue was completely idle.

Applied Fix
This PR resolves this by making the call to IndicateConfigChanged(SAVE_NOW) conditional on a changed boolean flag. Disk writes are now only triggered when an actual state change occurs within the queue (e.g., when a message is successfully sent, fails, or is updated), preserving the original fix without the I/O penalty.

Audit of the 24 Other Occurrences of IndicateConfigChanged
Beside the fix a thorough audit of the other 24 calls to IndicateConfigChanged inside p3msgservice.cc was conducted.
All 24 calls are relevant and correct. Unlike the one in the periodic loop, they are strictly bound to explicit, database-altering actions (e.g., deleting a message, marking emails as read/unread, or changing tags).
Two of these calls are executed closely together during message deletion. However, they are not critical because IndicateConfigChanged only sets an in-memory dirty flag. The actual disk serialization is handled asynchronously by the configuration manager (p3ConfigMgr), avoiding redundant writes. As a result, it was deemed unnecessary to modify them.