### PR TITLE
feature/relative-plugin-paths

### DIFF
--- a/src/plugins/pluginmanager.cc
+++ b/src/plugins/pluginmanager.cc
@@ -34,6 +34,7 @@
 
 #include <rsserver/p3face.h>
 #include <util/rsdir.h>
+#include <util/rsdebug.h>
 #include <retroshare/rsversion.h>
 #include <util/folderiterator.h>
 #include <ft/ftserver.h>
@@ -415,6 +416,9 @@ bool RsPluginManager::loadPlugin(const std::string& plugin_name,bool first_time)
 	pinfo.info_string = "" ;
 
 	_accepted_hashes.insert(pinfo.file_hash) ;	// do it now, to avoid putting in list a plugin that might have crashed during the load.
+	RsInfo() << "PLUGINSDIR: Successfully loaded plugin in memory: "
+	         << (p ? p->getPluginName() : "Unknown")
+	         << " from path: " << plugin_name;
 	return true;
 }
 

--- a/src/rsserver/rsinit.cc
+++ b/src/rsserver/rsinit.cc
@@ -1311,21 +1311,32 @@ int RsServer::StartupRetroShare()
 
 	// Add dynamic paths relative to the running binary first, to prevent cross-version conflicts!
 	std::string exe_path = RsInit::executablePath();
+	RsInfo() << "PLUGINSDIR: Raw executable path from RsInit: " << exe_path;
+
 	if (!exe_path.empty())
 	{
 		std::string canonical_exe_path = RsDirUtil::removeSymLinks(exe_path);
+		RsInfo() << "PLUGINSDIR: Canonicalized executable path: " << canonical_exe_path;
+
 		std::string exe_dir = RsDirUtil::getDirectory(canonical_exe_path.empty() ? exe_path : canonical_exe_path);
+		RsInfo() << "PLUGINSDIR: Extracted binary directory: " << exe_dir;
+
 		if (!exe_dir.empty())
 		{
+			RsInfo() << "PLUGINSDIR: Adding dynamic relative search path 1: " << exe_dir + "/../lib/retroshare/extensions6/";
 			plugins_directories.push_back(exe_dir + "/../lib/retroshare/extensions6/");
+
+			RsInfo() << "PLUGINSDIR: Adding dynamic relative search path 2: " << exe_dir + "/lib/retroshare/extensions6/";
 			plugins_directories.push_back(exe_dir + "/lib/retroshare/extensions6/");
 		}
 	}
 
 #if !defined(WINDOWS_SYS) && defined(PLUGIN_DIR)
+	RsInfo() << "PLUGINSDIR: Adding compile-time hardcoded PLUGIN_DIR: " << PLUGIN_DIR;
 	plugins_directories.push_back(std::string(PLUGIN_DIR)) ;
 #endif
 	std::string extensions_dir = RsAccounts::ConfigDirectory() + "/extensions6/" ;
+	RsInfo() << "PLUGINSDIR: Adding user home extensions directory: " << extensions_dir;
 	plugins_directories.push_back(extensions_dir) ;
 
 	// Canonicalize and de-duplicate directories to avoid double plugin loads and clean up listed paths
@@ -1354,6 +1365,12 @@ int RsServer::StartupRetroShare()
 		}
 	}
 	plugins_directories = unique_directories;
+
+	RsInfo() << "PLUGINSDIR: Final de-duplicated search directories:";
+	for (size_t i = 0; i < plugins_directories.size(); ++i)
+	{
+		RsInfo() << "PLUGINSDIR:   [" << i << "] -> " << plugins_directories[i];
+	}
 
 	if(!RsDirUtil::checkCreateDirectory(extensions_dir))
 		std::cerr << "(EE) Cannot create extensions directory " << extensions_dir

--- a/src/rsserver/rsinit.cc
+++ b/src/rsserver/rsinit.cc
@@ -60,6 +60,70 @@
 
 #include <list>
 #include <string>
+#include <vector>
+
+namespace {
+std::string resolvePathTextually(const std::string& path)
+{
+	if (path.empty()) return "";
+	bool is_absolute = (path[0] == '/');
+	bool has_drive = false;
+	std::string drive = "";
+	std::string rest = path;
+	if (path.size() >= 2 && path[1] == ':') {
+		has_drive = true;
+		drive = path.substr(0, 2);
+		rest = path.substr(2);
+		if (rest.size() > 0 && (rest[0] == '/' || rest[0] == '\\')) {
+			drive += rest[0];
+			rest = rest.substr(1);
+		}
+	}
+
+	std::vector<std::string> segments;
+	std::string segment;
+	for (size_t i = 0; i < rest.size(); ++i) {
+		char c = rest[i];
+		if (c == '/' || c == '\\') {
+			if (!segment.empty()) {
+				if (segment == "..") {
+					if (!segments.empty()) {
+						segments.pop_back();
+					}
+				} else if (segment != ".") {
+					segments.push_back(segment);
+				}
+				segment.clear();
+			}
+		} else {
+			segment.push_back(c);
+		}
+	}
+	if (!segment.empty()) {
+		if (segment == "..") {
+			if (!segments.empty()) {
+				segments.pop_back();
+			}
+		} else if (segment != ".") {
+			segments.push_back(segment);
+		}
+	}
+
+	std::string result = has_drive ? drive : (is_absolute ? "/" : "");
+	for (size_t i = 0; i < segments.size(); ++i) {
+		result += segments[i];
+		if (i + 1 < segments.size()) {
+			result += "/";
+		}
+	}
+	if (!path.empty() && (path.back() == '/' || path.back() == '\\')) {
+		if (result.empty() || (result.back() != '/' && result.back() != '\\')) {
+			result += "/";
+		}
+	}
+	return result;
+}
+} // namespace
 
 #include <dirent.h>
 #include <sys/types.h>
@@ -1343,9 +1407,10 @@ int RsServer::StartupRetroShare()
 	std::vector<std::string> unique_directories;
 	for (size_t i = 0; i < plugins_directories.size(); ++i)
 	{
-		std::string clean_dir = RsDirUtil::removeSymLinks(plugins_directories[i]);
-		if (clean_dir.empty()) {
-			clean_dir = plugins_directories[i];
+		std::string clean_dir = resolvePathTextually(plugins_directories[i]);
+		std::string sym_resolved = RsDirUtil::removeSymLinks(clean_dir);
+		if (!sym_resolved.empty()) {
+			clean_dir = sym_resolved;
 		}
 		if (!clean_dir.empty() && clean_dir.back() != '/' && clean_dir.back() != '\\') {
 			clean_dir += "/";

--- a/src/rsserver/rsinit.cc
+++ b/src/rsserver/rsinit.cc
@@ -1308,6 +1308,20 @@ int RsServer::StartupRetroShare()
 #ifdef __APPLE__
 	plugins_directories.push_back(RsAccounts::systemDataDirectory()) ;
 #endif
+
+	// Add dynamic paths relative to the running binary first, to prevent cross-version conflicts!
+	std::string exe_path = RsInit::executablePath();
+	if (!exe_path.empty())
+	{
+		std::string canonical_exe_path = RsDirUtil::removeSymLinks(exe_path);
+		std::string exe_dir = RsDirUtil::getDirectory(canonical_exe_path.empty() ? exe_path : canonical_exe_path);
+		if (!exe_dir.empty())
+		{
+			plugins_directories.push_back(exe_dir + "/../lib/retroshare/extensions6/");
+			plugins_directories.push_back(exe_dir + "/lib/retroshare/extensions6/");
+		}
+	}
+
 #if !defined(WINDOWS_SYS) && defined(PLUGIN_DIR)
 	plugins_directories.push_back(std::string(PLUGIN_DIR)) ;
 #endif

--- a/src/rsserver/rsinit.cc
+++ b/src/rsserver/rsinit.cc
@@ -1328,6 +1328,33 @@ int RsServer::StartupRetroShare()
 	std::string extensions_dir = RsAccounts::ConfigDirectory() + "/extensions6/" ;
 	plugins_directories.push_back(extensions_dir) ;
 
+	// Canonicalize and de-duplicate directories to avoid double plugin loads and clean up listed paths
+	std::vector<std::string> unique_directories;
+	for (size_t i = 0; i < plugins_directories.size(); ++i)
+	{
+		std::string clean_dir = RsDirUtil::removeSymLinks(plugins_directories[i]);
+		if (clean_dir.empty()) {
+			clean_dir = plugins_directories[i];
+		}
+		if (!clean_dir.empty() && clean_dir.back() != '/' && clean_dir.back() != '\\') {
+			clean_dir += "/";
+		}
+		bool already_exists = false;
+		for (size_t j = 0; j < unique_directories.size(); ++j)
+		{
+			if (unique_directories[j] == clean_dir)
+			{
+				already_exists = true;
+				break;
+			}
+		}
+		if (!already_exists)
+		{
+			unique_directories.push_back(clean_dir);
+		}
+	}
+	plugins_directories = unique_directories;
+
 	if(!RsDirUtil::checkCreateDirectory(extensions_dir))
 		std::cerr << "(EE) Cannot create extensions directory " << extensions_dir
                   << ". This is not mandatory, but you probably have a permission problem." << std::endl;


### PR DESCRIPTION
feature/relative-plugin-paths

Useful for testing environments. When running this branch, RetroShare will dynamically resolve the executable's directory and first look for plugins in ../lib/retroshare/extensions6/ and ./lib/retroshare/extensions6/ (relative to the binary's location) before falling back to the hardcoded system path.