### PR TITLE
build(cmake): describe the super-project for the displayed version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -816,9 +816,19 @@ else()
 	set(V_GIT_DESCRIBE_OUTPUT "")
 	set(V_GIT_DESCRIBE_REGEXP "^v([0-9]+).([0-9]+).([0-9]+)(.*)\n$")
 
+	# When libretroshare is built inside the RetroShare super-project (as a
+	# submodule), the displayed "RetroShare Version" must reflect the root
+	# repository, not this submodule. Describe the parent repo when present;
+	# fall back to this directory for standalone / FetchContent / Android
+	# builds where ../.git does not exist.
+	set(V_GIT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+	if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../.git")
+		set(V_GIT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
+	endif()
+
 	execute_process(
 		COMMAND ${GIT_EXECUTABLE} describe --tags --long --match v*.*.*
-		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+		WORKING_DIRECTORY "${V_GIT_DIR}"
 		OUTPUT_VARIABLE V_GIT_DESCRIBE_OUTPUT
 		RESULT_VARIABLE V_GIT_RESULT ) # Avoid CMake failure if git fails
 


### PR DESCRIPTION
ba90b271 dropped the parent-repo detection in the version block, so RS_MAJOR/MINOR/MINI/EXTRA_VERSION (and thus the GUI "RetroShare Version") now describe the libretroshare submodule instead of the RetroShare super-project. Restore the ../.git detection: describe the parent repo when libretroshare is built as a submodule, fall back to this directory for standalone / FetchContent / Android builds.