### PR TITLE
fix(net): don't apply peer-reported external address on hidden nodes

### DIFF
--- a/src/pqi/p3peermgr.cc
+++ b/src/pqi/p3peermgr.cc
@@ -1770,6 +1770,16 @@ struct ZeroedInt
 
 bool p3PeerMgrIMPL::addCandidateForOwnExternalAddress(const RsPeerId &from, const sockaddr_storage &addr)
 {
+    // Hidden nodes (Tor/I2P) have no usable clear-net external address: addresses
+    // reported by friends are meaningless for them. Since commit bb4e8c5d such a
+    // reported candidate is actually applied through mNetMgr->setExtAddress(), which
+    // triggers UpdateOwnAddress()/netReset(). For a hidden node this clobbers the
+    // local forward port, which p3NetMgrIMPL::checkNetAddress() then re-randomizes
+    // when it ends up 0 -> the I2P/SAM forward port keeps changing on every restart.
+    // Simply ignore peer-reported external addresses when we are a hidden node.
+    if(isHiddenNode(getOwnId()))
+        return false;
+
     // The algorithm is the following:
     // - collect for each friend the last external connection address that is reported
     // - everytime the list is changed, parse it entirely and


### PR DESCRIPTION
Regression from bb4e8c5d ("added update of external address when needed"): addCandidateForOwnExternalAddress() now actually applies the peer-reported external address via mNetMgr->setExtAddress() instead of only computing it.

For Tor/I2P hidden nodes this is wrong — they have no clear-net external address. The applied candidate carries port 0 (built with clear()+copyip()) and the setExtAddress() -> UpdateOwnAddress()/netReset() churn clobbers the local forward port. p3NetMgrIMPL::checkNetAddress() then re-randomizes it whenever it is 0, so the I2P/SAM forward port (e.g. 7812) changes to a random high port on every restart — breaking external I2P router port-forwarding.

Guard addCandidateForOwnExternalAddress(): ignore peer-reported external addresses when we are a hidden node, restoring the pre-bb4e8c5d behaviour for hidden nodes while keeping the improvement for clear-net nodes.