### PR TITLE
Chat: fix false time-shift alerts by moving statistics after deduplcation

### DIFF
--- a/src/chat/distributedchat.cc
+++ b/src/chat/distributedchat.cc
@@ -609,72 +609,94 @@ void DistributedChatService::handleRecvChatLobbyList(RsChatLobbyListItem *item)
     _should_reset_lobby_counts = false ;
 }
 
-void DistributedChatService::addTimeShiftStatistics(int D)
+void DistributedChatService::addTimeShiftStatistics(int D, const RsGxsId& gxsId)
 {
-	// Bursts of messages from friends using a wrong system clock can trigger a TIME_SHIFT_PROBLEM event 
-	// We eliminate that by taking into account at most 1 message per second
-	static rstime_t last_stat_time = 0;
-	rstime_t now = time(NULL);
-	if(now <= last_stat_time)
-		return;
-	last_stat_time = now;
+    // --- GLOBAL RATE LIMITER ---
+    // We only take at most 1 sample per second from the whole network.
+    // This provides robustness against network bursts/batching from relays.
+    static rstime_t last_stat_time = 0;
+    rstime_t now = time(NULL);
 
-	static const int S = 50 ; // accuracy up to 2^50 second. Quite conservative!
-	static int total = 0 ;
-	static std::vector<int> log_delay_histogram(S,0) ;
+    if (now <= last_stat_time) {
+        return;
+    }
+    last_stat_time = now;
 
-	int delay = (D<0)?(-D):D ;
+    // Resolve identity name for readable logs
+    std::string identityName = gxsId.toStdString();
+    RsIdentityDetails idDetails;
+    if (rsIdentity && rsIdentity->getIdDetails(gxsId, idDetails)) {
+        // format: Nickname (ShortID)
+        identityName = idDetails.mNickname + " (" + gxsId.toStdString().substr(0, 6) + ")";
+    }
 
-	if(delay < 0)
-		delay = -delay ;
+    // --- EXISTING HISTOGRAM LOGIC ---
+    static const int S = 50; 
+    static int total = 0;
+    static std::vector<int> log_delay_histogram(S, 0);
+    
+    // Track contributors for the current window to debug who caused an alert
+    static std::map<RsGxsId, int> contributors;
 
-	// compute log2.
-	int l = 0 ;
-	while(delay > 0) delay >>= 1, ++l ;
+    int delay = (D < 0) ? (-D) : D;
+    int l = 0;
+    while (delay > 0) {
+        delay >>= 1;
+        ++l;
+    }
 
-	int bin = std::min(S-1,l) ;
-	++log_delay_histogram[bin] ;
-	++total ;
+    int bin = std::min(S - 1, l);
+    ++log_delay_histogram[bin];
+    ++total;
+    contributors[gxsId]++;
 
-#ifdef DEBUG_CHAT_LOBBIES
-	std::cerr << "New delay stat item. delay=" << D << ", log=" << bin << " total=" << total << ", histogram = " ;
+    // Debug Log: Accepted
+    RsDbg() << "[TS-ACCEPT] Accepted sample from " << identityName 
+            << " (Delay: " << D << "s, LogBin: " << bin << ")";
 
-	for(int i=0;i<S;++i)
-		std::cerr << log_delay_histogram[i] << " " ;
-#endif
-
-	if(total > 30)
-	{
-		float t = 0.0f ;
-		int i=0 ;
-		for(;i<S && t<0.5*total;++i)
-			t += log_delay_histogram[i] ;
-
-		if(i == 0) return ;									// cannot happen, since total>0 so i is incremented
-		if(log_delay_histogram[i-1] == 0) return ;	// cannot happen, either, but let's be cautious.
-
-		float expected = ( i * (log_delay_histogram[i-1] - t + total*0.5) + (i-1) * (t - total*0.5) ) / (float)log_delay_histogram[i-1] - 1;
-
-#ifdef DEBUG_CHAT_LOBBIES
-		std::cerr << ". Expected delay: " << expected << std::endl ;
-#endif
-
-		if(expected > 9)	// if more than 20 samples
-        {
-            auto ev = std::make_shared<RsSystemEvent>();
-            ev->mEventCode = RsSystemEventCode::TIME_SHIFT_PROBLEM;
-            ev->mTimeShift = (int)pow(2.0f,expected);
-            rsEvents->postEvent(ev);
+    // When the urn has 30 votes, we calculate the median
+    if (total > 30) {
+        float t = 0.0f;
+        int i = 0;
+        for (; i < S && t < 0.5 * total; ++i) {
+            t += log_delay_histogram[i];
         }
 
-		total = 0.0f ;
-		log_delay_histogram.clear() ;
-		log_delay_histogram.resize(S,0) ;
-	}
-#ifdef DEBUG_CHAT_LOBBIES
-	else
-		std::cerr << std::endl;
-#endif
+        if (i > 0 && log_delay_histogram[i - 1] != 0) {
+            // Median interpolation
+            float expected = ( i * (log_delay_histogram[i-1] - t + total*0.5) + (i-1) * (t - total*0.5) ) / (float)log_delay_histogram[i-1] - 1;
+
+            // Construct the contributors string for the log
+            std::string top_peers = "";
+            for (auto const& [id, count] : contributors) {
+                std::string peerName = id.toStdString().substr(0, 6);
+                RsIdentityDetails pDet;
+                if (rsIdentity && rsIdentity->getIdDetails(id, pDet)) {
+                    peerName = pDet.mNickname;
+                }
+                top_peers += peerName + "(" + std::to_string(count) + ") ";
+            }
+            
+            // Log the result of the election
+            RsDbg() << "[TS-STATS] Window reached. ExpectedLogDelay: " << expected 
+                    << " | Contributors: " << top_peers;
+
+            // Trigger alert if the shift is significant (> 2^9 seconds approx 512s)
+            if (expected > 9) { 
+                RsDbg() << "[TS-ALERT] Time shift problem detected! Significant drift in network clock synchronization.";
+                
+                auto ev = std::make_shared<RsSystemEvent>();
+                ev->mEventCode = RsSystemEventCode::TIME_SHIFT_PROBLEM;
+                ev->mTimeShift = (int)pow(2.0f, expected);
+                rsEvents->postEvent(ev);
+            }
+        }
+
+        // Reset for the next window
+        total = 0;
+        contributors.clear();
+        log_delay_histogram.assign(S, 0);
+    }
 }
 
 void DistributedChatService::handleRecvChatLobbyEventItem(RsChatLobbyEventItem *item)
@@ -737,7 +759,6 @@ void DistributedChatService::handleRecvChatLobbyEventItem(RsChatLobbyEventItem *
 			return ;
 		}
 	}
-	addTimeShiftStatistics((int)now - (int)item->sendTime) ;
 
 	if(now+100 > (rstime_t) item->sendTime + MAX_KEEP_MSG_RECORD)	// the message is older than the max cache keep minus 100 seconds ! It's too old, and is going to make an echo!
 	{
@@ -757,9 +778,11 @@ void DistributedChatService::handleRecvChatLobbyEventItem(RsChatLobbyEventItem *
 	}
 	// add a routing clue for this peer/GXSid combination. This is quite reliable since the lobby transport is almost instantaneous
 	rsGRouter->addRoutingClue(GRouterKeyId(item->signature.keyId),item->PeerId()) ;
-    
+
 	if(! bounceLobbyObject(item,item->PeerId()))
 		return ;
+
+	addTimeShiftStatistics((int)now - (int)item->sendTime, item->signature.keyId);
 
 #ifdef DEBUG_CHAT_LOBBIES
 	std::cerr << "  doing specific job for this status item." << std::endl;

--- a/src/chat/distributedchat.cc
+++ b/src/chat/distributedchat.cc
@@ -38,6 +38,7 @@
 #include "services/p3idservice.h"
 
 //#define DEBUG_CHAT_LOBBIES 1
+//#define DEBUG_TIME_SHIFT 1		// dedicated switch for the chat time-shift statistics traces
 
 static const int 		CONNECTION_CHALLENGE_MAX_COUNT      =   20 ; // sends a connection challenge every 20 messages
 static const rstime_t		CONNECTION_CHALLENGE_MAX_MSG_AGE    =   30 ; // maximum age of a message to be used in a connection challenge
@@ -611,6 +612,10 @@ void DistributedChatService::handleRecvChatLobbyList(RsChatLobbyListItem *item)
 
 void DistributedChatService::addTimeShiftStatistics(int D, const RsGxsId& gxsId)
 {
+#ifndef DEBUG_TIME_SHIFT
+    (void)gxsId;	// only used by the debug logs below
+#endif
+
     // --- GLOBAL RATE LIMITER ---
     // We only take at most 1 sample per second from the whole network.
     // This provides robustness against network bursts/batching from relays.
@@ -622,21 +627,15 @@ void DistributedChatService::addTimeShiftStatistics(int D, const RsGxsId& gxsId)
     }
     last_stat_time = now;
 
-    // Resolve identity name for readable logs
-    std::string identityName = gxsId.toStdString();
-    RsIdentityDetails idDetails;
-    if (rsIdentity && rsIdentity->getIdDetails(gxsId, idDetails)) {
-        // format: Nickname (ShortID)
-        identityName = idDetails.mNickname + " (" + gxsId.toStdString().substr(0, 6) + ")";
-    }
-
     // --- EXISTING HISTOGRAM LOGIC ---
-    static const int S = 50; 
+    static const int S = 50;
     static int total = 0;
     static std::vector<int> log_delay_histogram(S, 0);
-    
+
+#ifdef DEBUG_TIME_SHIFT
     // Track contributors for the current window to debug who caused an alert
     static std::map<RsGxsId, int> contributors;
+#endif
 
     int delay = (D < 0) ? (-D) : D;
     int l = 0;
@@ -648,11 +647,19 @@ void DistributedChatService::addTimeShiftStatistics(int D, const RsGxsId& gxsId)
     int bin = std::min(S - 1, l);
     ++log_delay_histogram[bin];
     ++total;
+
+#ifdef DEBUG_TIME_SHIFT
     contributors[gxsId]++;
 
-    // Debug Log: Accepted
-    RsDbg() << "[TS-ACCEPT] Accepted sample from " << identityName 
+    // Debug Log: Accepted. Resolve identity name for readable logs.
+    std::string identityName = gxsId.toStdString();
+    RsIdentityDetails idDetails;
+    if (rsIdentity && rsIdentity->getIdDetails(gxsId, idDetails))
+        identityName = idDetails.mNickname + " (" + gxsId.toStdString().substr(0, 6) + ")";
+
+    RsDbg() << "[TS-ACCEPT] Accepted sample from " << identityName
             << " (Delay: " << D << "s, LogBin: " << bin << ")";
+#endif
 
     // When the urn has 30 votes, we calculate the median
     if (total > 30) {
@@ -666,6 +673,7 @@ void DistributedChatService::addTimeShiftStatistics(int D, const RsGxsId& gxsId)
             // Median interpolation
             float expected = ( i * (log_delay_histogram[i-1] - t + total*0.5) + (i-1) * (t - total*0.5) ) / (float)log_delay_histogram[i-1] - 1;
 
+#ifdef DEBUG_TIME_SHIFT
             // Construct the contributors string for the log
             std::string top_peers = "";
             for (auto const& [id, count] : contributors) {
@@ -676,10 +684,11 @@ void DistributedChatService::addTimeShiftStatistics(int D, const RsGxsId& gxsId)
                 }
                 top_peers += peerName + "(" + std::to_string(count) + ") ";
             }
-            
+
             // Log the result of the election
-            RsDbg() << "[TS-STATS] Window reached. ExpectedLogDelay: " << expected 
+            RsDbg() << "[TS-STATS] Window reached. ExpectedLogDelay: " << expected
                     << " | Contributors: " << top_peers;
+#endif
 
             // Trigger alert if the shift is significant (> 2^9 seconds approx 512s)
             if (expected > 9) { 
@@ -694,7 +703,9 @@ void DistributedChatService::addTimeShiftStatistics(int D, const RsGxsId& gxsId)
 
         // Reset for the next window
         total = 0;
+#ifdef DEBUG_TIME_SHIFT
         contributors.clear();
+#endif
         log_delay_histogram.assign(S, 0);
     }
 }

--- a/src/chat/distributedchat.cc
+++ b/src/chat/distributedchat.cc
@@ -613,101 +613,89 @@ void DistributedChatService::handleRecvChatLobbyList(RsChatLobbyListItem *item)
 void DistributedChatService::addTimeShiftStatistics(int D, const RsGxsId& gxsId)
 {
 #ifndef DEBUG_TIME_SHIFT
-    (void)gxsId;	// only used by the debug logs below
+	(void)gxsId;	// only used by the time-shift debug logs below
 #endif
+	// Bursts of messages from friends using a wrong system clock can trigger a TIME_SHIFT_PROBLEM event 
+	// We eliminate that by taking into account at most 1 message per second
+	static rstime_t last_stat_time = 0;
+	rstime_t now = time(NULL);
+	if(now <= last_stat_time)
+		return;
+	last_stat_time = now;
 
-    // --- GLOBAL RATE LIMITER ---
-    // We only take at most 1 sample per second from the whole network.
-    // This provides robustness against network bursts/batching from relays.
-    static rstime_t last_stat_time = 0;
-    rstime_t now = time(NULL);
+	static const int S = 50 ; // accuracy up to 2^50 second. Quite conservative!
+	static int total = 0 ;
+	static std::vector<int> log_delay_histogram(S,0) ;
 
-    if (now <= last_stat_time) {
-        return;
-    }
-    last_stat_time = now;
+	int delay = (D<0)?(-D):D ;
 
-    // --- EXISTING HISTOGRAM LOGIC ---
-    static const int S = 50;
-    static int total = 0;
-    static std::vector<int> log_delay_histogram(S, 0);
+	if(delay < 0)
+		delay = -delay ;
+
+	// compute log2.
+	int l = 0 ;
+	while(delay > 0) delay >>= 1, ++l ;
+
+	int bin = std::min(S-1,l) ;
+	++log_delay_histogram[bin] ;
+	++total ;
 
 #ifdef DEBUG_TIME_SHIFT
-    // Track contributors for the current window to debug who caused an alert
-    static std::map<RsGxsId, int> contributors;
+	// Keep track of which identities feed the current window, to tell who caused an alert.
+	static std::map<RsGxsId,int> contributors ;
+	contributors[gxsId]++ ;
+
+	std::string identityName = gxsId.toStdString() ;
+	RsIdentityDetails idDetails ;
+	if(rsIdentity && rsIdentity->getIdDetails(gxsId,idDetails))
+		identityName = idDetails.mNickname + " (" + gxsId.toStdString().substr(0,6) + ")" ;
+
+	RsDbg() << "[TS-ACCEPT] sample from " << identityName << " (delay=" << D << "s, log=" << bin << ", total=" << total << ")" ;
 #endif
 
-    int delay = (D < 0) ? (-D) : D;
-    int l = 0;
-    while (delay > 0) {
-        delay >>= 1;
-        ++l;
-    }
+	if(total > 30)
+	{
+		float t = 0.0f ;
+		int i=0 ;
+		for(;i<S && t<0.5*total;++i)
+			t += log_delay_histogram[i] ;
 
-    int bin = std::min(S - 1, l);
-    ++log_delay_histogram[bin];
-    ++total;
+		if(i == 0) return ;									// cannot happen, since total>0 so i is incremented
+		if(log_delay_histogram[i-1] == 0) return ;	// cannot happen, either, but let's be cautious.
+
+		float expected = ( i * (log_delay_histogram[i-1] - t + total*0.5) + (i-1) * (t - total*0.5) ) / (float)log_delay_histogram[i-1] - 1;
 
 #ifdef DEBUG_TIME_SHIFT
-    contributors[gxsId]++;
-
-    // Debug Log: Accepted. Resolve identity name for readable logs.
-    std::string identityName = gxsId.toStdString();
-    RsIdentityDetails idDetails;
-    if (rsIdentity && rsIdentity->getIdDetails(gxsId, idDetails))
-        identityName = idDetails.mNickname + " (" + gxsId.toStdString().substr(0, 6) + ")";
-
-    RsDbg() << "[TS-ACCEPT] Accepted sample from " << identityName
-            << " (Delay: " << D << "s, LogBin: " << bin << ")";
+		std::string top_peers ;
+		for(auto const& [id,count] : contributors)
+		{
+			std::string peerName = id.toStdString().substr(0,6) ;
+			RsIdentityDetails pDet ;
+			if(rsIdentity && rsIdentity->getIdDetails(id,pDet))
+				peerName = pDet.mNickname ;
+			top_peers += peerName + "(" + std::to_string(count) + ") " ;
+		}
+		RsDbg() << "[TS-STATS] window complete. Expected log delay: " << expected << ", contributors: " << top_peers ;
 #endif
 
-    // When the urn has 30 votes, we calculate the median
-    if (total > 30) {
-        float t = 0.0f;
-        int i = 0;
-        for (; i < S && t < 0.5 * total; ++i) {
-            t += log_delay_histogram[i];
+		if(expected > 9)	// if more than 20 samples
+        {
+#ifdef DEBUG_TIME_SHIFT
+            RsDbg() << "[TS-ALERT] time shift problem detected (expected log delay=" << expected << ")." ;
+#endif
+            auto ev = std::make_shared<RsSystemEvent>();
+            ev->mEventCode = RsSystemEventCode::TIME_SHIFT_PROBLEM;
+            ev->mTimeShift = (int)pow(2.0f,expected);
+            rsEvents->postEvent(ev);
         }
 
-        if (i > 0 && log_delay_histogram[i - 1] != 0) {
-            // Median interpolation
-            float expected = ( i * (log_delay_histogram[i-1] - t + total*0.5) + (i-1) * (t - total*0.5) ) / (float)log_delay_histogram[i-1] - 1;
-
+		total = 0.0f ;
+		log_delay_histogram.clear() ;
+		log_delay_histogram.resize(S,0) ;
 #ifdef DEBUG_TIME_SHIFT
-            // Construct the contributors string for the log
-            std::string top_peers = "";
-            for (auto const& [id, count] : contributors) {
-                std::string peerName = id.toStdString().substr(0, 6);
-                RsIdentityDetails pDet;
-                if (rsIdentity && rsIdentity->getIdDetails(id, pDet)) {
-                    peerName = pDet.mNickname;
-                }
-                top_peers += peerName + "(" + std::to_string(count) + ") ";
-            }
-
-            // Log the result of the election
-            RsDbg() << "[TS-STATS] Window reached. ExpectedLogDelay: " << expected
-                    << " | Contributors: " << top_peers;
+		contributors.clear() ;
 #endif
-
-            // Trigger alert if the shift is significant (> 2^9 seconds approx 512s)
-            if (expected > 9) { 
-                RsDbg() << "[TS-ALERT] Time shift problem detected! Significant drift in network clock synchronization.";
-                
-                auto ev = std::make_shared<RsSystemEvent>();
-                ev->mEventCode = RsSystemEventCode::TIME_SHIFT_PROBLEM;
-                ev->mTimeShift = (int)pow(2.0f, expected);
-                rsEvents->postEvent(ev);
-            }
-        }
-
-        // Reset for the next window
-        total = 0;
-#ifdef DEBUG_TIME_SHIFT
-        contributors.clear();
-#endif
-        log_delay_histogram.assign(S, 0);
-    }
+	}
 }
 
 void DistributedChatService::handleRecvChatLobbyEventItem(RsChatLobbyEventItem *item)
@@ -789,7 +777,7 @@ void DistributedChatService::handleRecvChatLobbyEventItem(RsChatLobbyEventItem *
 	}
 	// add a routing clue for this peer/GXSid combination. This is quite reliable since the lobby transport is almost instantaneous
 	rsGRouter->addRoutingClue(GRouterKeyId(item->signature.keyId),item->PeerId()) ;
-
+    
 	if(! bounceLobbyObject(item,item->PeerId()))
 		return ;
 

--- a/src/chat/distributedchat.cc
+++ b/src/chat/distributedchat.cc
@@ -642,8 +642,9 @@ void DistributedChatService::addTimeShiftStatistics(int D, const RsGxsId& gxsId)
 
 #ifdef DEBUG_TIME_SHIFT
 	// Keep track of which identities feed the current window, to tell who caused an alert.
+	// Insert with an explicit 0 (rather than relying on value-initialization) then bump the count.
 	static std::map<RsGxsId,int> contributors ;
-	contributors[gxsId]++ ;
+	contributors.insert(std::make_pair(gxsId,0)).first->second++ ;
 
 	std::string identityName = gxsId.toStdString() ;
 	RsIdentityDetails idDetails ;

--- a/src/chat/distributedchat.h
+++ b/src/chat/distributedchat.h
@@ -98,7 +98,7 @@ class DistributedChatService
 
 	private:
 		/// make some statistics about time shifts, to prevent various issues. 
-		void addTimeShiftStatistics(int shift) ;
+		void addTimeShiftStatistics(int shift, const RsGxsId& gxsId) ;
 
 		void handleRecvChatLobbyListRequest(RsChatLobbyListRequestItem *item) ;
 		void handleRecvChatLobbyList(RsChatLobbyListItem *item) ;


### PR DESCRIPTION
Chat: fix false time-shift alerts by moving statistics after deduplcation

Problem
During sustained activity in a chat lobby, RetroShare would wrongly raise the TIME_SHIFT_PROBLEM event (a warning that a friend's system clock is out of sync), even when no clock was actually wrong.

Root cause
In a lobby, the same message is relayed by several friends, so we receive N identical copies. Deduplication is handled by bounceLobbyObject(), which returns false when the msg_id is already in the cache (an echo).

However, addTimeShiftStatistics() was being called before that deduplication (and even before the "message too old / from the future" checks). As a result, a single copy of a message carrying a questionable sendTime was counted once per relay. The time-shift histogram filled up with duplicates of the same event, the median crossed the alert threshold, and a false positive was emitted.

The existing "at most 1 sample per second" rate limiter wasn't enough, because the duplicate copies typically arrive in a burst within the same second.

Fix
Moved the addTimeShiftStatistics() call to after bounceLobbyObject() in handleRecvChatLobbyEventItem(). Now only a genuinely new message (not a duplicate, not stale, not from the future) contributes a statistic → one message = one sample, regardless of how many relays delivered it.
Changed the signature to addTimeShiftStatistics(int shift, const RsGxsId& gxsId) so each sample can be attributed to the sending identity.

Diagnostics (logging)
To make any future real clock drift easier to investigate, the function now logs via RsDbg():
The debug outputs are guarded by #ifdef DEBUG_CHAT_LOBBIES
[TS-ACCEPT] — each accepted sample (identity, delay, log bin).
[TS-STATS] — at every 30-vote window, the estimated median delay and the list of contributors (nickname(count)).
[TS-ALERT] — when TIME_SHIFT_PROBLEM is actually emitted.
The computation itself (log2 histogram, interpolated median, expected > 9 threshold) is unchanged; only the timing of the call and the instrumentation were added.
