### PR TITLE
build(cmake): add RS_NO_LTO opt-out for the Release LTO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -890,7 +890,10 @@ endif()
 # because enabling it causes the MinGW linker (ld) to run out of memory or exhaust the maximum
 # number of exported symbols, or emit "multiple definition" errors during LTO code generation. 
 # While this makes the binary fatter and slower, it prevents fatal build failures.
-if(CMAKE_BUILD_TYPE STREQUAL "Release" AND NOT WIN32)
+# The same escape hatch (-DRS_NO_LTO=ON) also works around lto1 internal compiler
+# errors (segfault in the IPA icf pass) with the older GCC 10 LTO plugin, e.g. when
+# building on Debian 11 to produce a portable (old-glibc) AppImage.
+if(CMAKE_BUILD_TYPE STREQUAL "Release" AND NOT WIN32 AND NOT RS_NO_LTO)
 	set_property(TARGET ${PROJECT_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION ON)
 endif()
 


### PR DESCRIPTION
What
Adds an RS_NO_LTO opt-out to the Release LTO (INTERPROCEDURAL_OPTIMIZATION) on libretroshare, mirroring the existing Windows carve-out.

Why
GCC 10's LTO plugin crashes with lto1: internal compiler error: Segmentation fault (IPA icf pass) when linking libretroshare in Release, breaking the build on older toolchains. This happens when building on Debian 11 (glibc 2.31) - the usual "build on old, run everywhere" base for a portable AppImage.

Change
-DRS_NO_LTO=ON skips enabling LTO. Default behaviour unchanged (LTO stays on for Release/non-Windows). LTO is only an optimization here.