### PR TITLE
build(cmake): add options to build the GXS Wiki and The Wire services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,16 @@ option(
 	OFF )
 
 option(
+	RS_GXSWIKIPOS
+	"Build the experimental, off-by-default GXS Wiki (WikiPoos) service"
+	OFF )
+
+option(
+	RS_GXSTHEWIRE
+	"Build the experimental, off-by-default GXS 'The Wire' service"
+	OFF )
+
+option(
 	RS_LIBRETROSHARE_STANDALONE_INSTALL
 	"Install libretroshare as a stand-alone library"
 	OFF )
@@ -716,6 +726,20 @@ if(RS_USE_CALENDAR)
 	target_compile_definitions(
 		${PROJECT_NAME} PUBLIC RS_USE_CALENDAR )
 endif(RS_USE_CALENDAR)
+
+# Enable the experimental GXS Wiki (WikiPoos) service. The define is PUBLIC so
+# that consumers (retroshare-gui, retroshare-service) that link libretroshare
+# see the same RS_USE_WIKI guard used in rsserver/rsinit.cc and the GUI.
+if(RS_GXSWIKIPOS)
+	target_compile_definitions(
+		${PROJECT_NAME} PUBLIC RS_USE_WIKI )
+endif(RS_GXSWIKIPOS)
+
+# Enable the experimental GXS 'The Wire' service (see note above).
+if(RS_GXSTHEWIRE)
+	target_compile_definitions(
+		${PROJECT_NAME} PUBLIC RS_USE_WIRE )
+endif(RS_GXSTHEWIRE)
 
 if(RS_BRODCAST_DISCOVERY)
 	## TODO: upstream option to disable tests building

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -364,9 +364,6 @@ list(
 	rsitems/rsrttitems.cc
 	rsitems/rsserviceinfoitems.cc )
 
-# NOTE: rswikiitems / rswireitems sources are added further below in the
-# services section, guarded by the RS_GXSWIKIPOS / RS_GXSTHEWIRE options.
-
 list(
 	APPEND RS_SOURCES
 	rsitems/rsgxschannelitems.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -364,10 +364,8 @@ list(
 	rsitems/rsrttitems.cc
 	rsitems/rsserviceinfoitems.cc )
 
-#retroshare/rswiki.h
-#./rsitems/rswikiitems.cc
-#./rsitems/rswikiitems.h
-#./rsitems/rswireitems.h
+# NOTE: rswikiitems / rswireitems sources are added further below in the
+# services section, guarded by the RS_GXSWIKIPOS / RS_GXSTHEWIRE options.
 
 list(
 	APPEND RS_SOURCES
@@ -379,8 +377,6 @@ list(
 #./rsitems/rsphotoitems.cc
 #./rsitems/rsphotoitems.h
 #./rsitems/rsposteditems.h
-#./rsitems/rswireitems.cc
-#retroshare/rswire.h
 
 list(
 	APPEND RS_SOURCES
@@ -545,10 +541,43 @@ if(RS_USE_CALENDAR)
 		services/p3gxscalendar.h )
 endif(RS_USE_CALENDAR)
 	
-#./services/p3wiki.cc
-#./services/p3wiki.h
-#./services/p3wire.cc
-#./services/p3wire.h
+# The Wiki (WikiPoos) and The Wire are experimental, off-by-default GXS
+# services. Their sources are compiled only when the matching option is set.
+# The options live in the top-level CMakeLists.txt (RS_GXSWIKIPOS /
+# RS_GXSTHEWIRE), which also adds the RS_USE_WIKI / RS_USE_WIRE compile
+# definitions that gate the service instantiation in rsserver/rsinit.cc and
+# the corresponding GUI code.
+if(RS_GXSWIKIPOS)
+	list(
+		APPEND RS_SOURCES
+		services/p3wiki.cc
+		rsitems/rswikiitems.cc )
+
+	list(
+		APPEND RS_IMPLEMENTATION_HEADERS
+		services/p3wiki.h
+		rsitems/rswikiitems.h )
+
+	list(
+		APPEND RS_PUBLIC_HEADERS
+		retroshare/rswiki.h )
+endif(RS_GXSWIKIPOS)
+
+if(RS_GXSTHEWIRE)
+	list(
+		APPEND RS_SOURCES
+		services/p3wire.cc
+		rsitems/rswireitems.cc )
+
+	list(
+		APPEND RS_IMPLEMENTATION_HEADERS
+		services/p3wire.h
+		rsitems/rswireitems.h )
+
+	list(
+		APPEND RS_PUBLIC_HEADERS
+		retroshare/rswire.h )
+endif(RS_GXSTHEWIRE)
 
 #./services/p3photoservice.cc
 #./services/p3photoservice.h


### PR DESCRIPTION
The CMake build never compiled the experimental GXS "Wiki" (WikiPoos) and "The Wire" services: their sources were commented out in src/CMakeLists.txt and no option defined the RS_USE_WIKI / RS_USE_WIRE macros that gate the service instantiation in rsserver/rsinit.cc and the matching GUI code. As a result the retroshare-gui RS_GXSWIKIPOS / RS_GXSTHEWIRE blocks could not be enabled to a working build.

Mirror the qmake "wikipoos" / "gxsthewire" CONFIG switches:

- Add RS_GXSWIKIPOS and RS_GXSTHEWIRE options (default OFF, as in qmake).
- Compile the p3wiki/p3wire services, rswikiitems/rswireitems and the rswiki.h/rswire.h public headers when the respective option is enabled.
- Define RS_USE_WIKI / RS_USE_WIRE PUBLIC so libretroshare consumers see the same guard.

Both features stay OFF by default; they are unmaintained and experimental.