### PR TITLE
Posted boards: support editing posts (createPostV2) and pinning/sticking posts

### DIFF
--- a/src/retroshare/rsposted.h
+++ b/src/retroshare/rsposted.h
@@ -32,6 +32,7 @@
 #include "retroshare/rsgxscommon.h"
 #include "retroshare/rsgxscircles.h"
 #include "serialiser/rsserializable.h"
+#include "serialiser/rstlvidset.h"
 
 class RsPosted;
 
@@ -46,6 +47,13 @@ struct RsPostedGroup: public RsSerializable, RsGxsGenericGroupData
 	std::string mDescription;
 	RsGxsImage mGroupImage;
 
+	/** @brief List of board pinned (a.k.a. "stuck") posts, those are usually
+	 * displayed on top of the feed regardless of the current sorting
+	 * strategy.
+	 * @todo run away from TLV old serializables as those types are opaque to
+	 * JSON API! */
+	RsTlvGxsMsgIdSet mPinnedPosts;
+
 	/// @see RsSerializable
 	virtual void serial_process( RsGenericSerializer::SerializeJob j,
 								 RsGenericSerializer::SerializeContext& ctx ) override
@@ -53,6 +61,7 @@ struct RsPostedGroup: public RsSerializable, RsGxsGenericGroupData
 		RS_SERIAL_PROCESS(mMeta);
 		RS_SERIAL_PROCESS(mDescription);
 		RS_SERIAL_PROCESS(mGroupImage);
+		RS_SERIAL_PROCESS(mPinnedPosts);
 	}
 };
 
@@ -131,6 +140,7 @@ enum class RsPostedEventCode: uint8_t
 	NEW_COMMENT              = 0x0a,
 	NEW_VOTE                 = 0x0b,
 	BOARD_DELETED            = 0x0c,
+	PINNED_POSTS_CHANGED     = 0x0d, /// some posts where pinned or un-pinned
 };
 
 
@@ -299,7 +309,8 @@ public:
                       const RsGxsId& authorId,
                       const RsGxsImage& image,
                       RsGxsMessageId& postId,
-                      std::string& error_message) =0;
+                      std::string& error_message,
+                      const RsGxsMessageId& origPostId = RsGxsMessageId()) =0;
 
     /** @brief Add a comment on a post or on another comment. Blocking API.
      * @jsonapi{development}

--- a/src/services/p3postbase.cc
+++ b/src/services/p3postbase.cc
@@ -27,6 +27,7 @@
 
 #include "services/p3postbase.h"
 #include "rsitems/rsgxscommentitems.h"
+#include "rsitems/rsposteditems.h"
 
 #include "rsserver/p3face.h"
 #include "retroshare/rsposted.h"
@@ -215,6 +216,38 @@ void p3PostBase::notifyChanges(std::vector<RsGxsNotify *> &changes)
                 ev->mPostedGroupId = grpChange->mGroupId;
                 ev->mPostedEventCode = RsPostedEventCode::UPDATED_POSTED_GROUP;
                 rsEvents->postEvent(ev);
+
+                // Also check whether the list of pinned/stuck posts changed,
+                // so that clients that only care about pinning don't have to
+                // reload everything (mirrors what is done for forums).
+
+                RsGxsPostedGroupItem* old_posted_grp_item =
+                        dynamic_cast<RsGxsPostedGroupItem*>(grpChange->mOldGroupItem);
+                RsGxsPostedGroupItem* new_posted_grp_item =
+                        dynamic_cast<RsGxsPostedGroupItem*>(grpChange->mNewGroupItem);
+
+                if(old_posted_grp_item && new_posted_grp_item)
+                {
+                    std::list<RsGxsMessageId> added_pins, removed_pins;
+
+                    for(auto& msg_id: new_posted_grp_item->mGroup.mPinnedPosts.ids)
+                        if( old_posted_grp_item->mGroup.mPinnedPosts.ids.find(msg_id)
+                                == old_posted_grp_item->mGroup.mPinnedPosts.ids.end() )
+                            added_pins.push_back(msg_id);
+
+                    for(auto& msg_id: old_posted_grp_item->mGroup.mPinnedPosts.ids)
+                        if( new_posted_grp_item->mGroup.mPinnedPosts.ids.find(msg_id)
+                                == new_posted_grp_item->mGroup.mPinnedPosts.ids.end() )
+                            removed_pins.push_back(msg_id);
+
+                    if(!added_pins.empty() || !removed_pins.empty())
+                    {
+                        auto pin_ev = std::make_shared<RsGxsPostedEvent>();
+                        pin_ev->mPostedGroupId = grpChange->mGroupId;
+                        pin_ev->mPostedEventCode = RsPostedEventCode::PINNED_POSTS_CHANGED;
+                        rsEvents->postEvent(pin_ev);
+                    }
+                }
             }
                 break;
 

--- a/src/services/p3posted.cc
+++ b/src/services/p3posted.cc
@@ -730,7 +730,8 @@ bool p3Posted::createPostV2(const RsGxsGroupId& boardId,
                             const RsGxsId& authorId,
                             const RsGxsImage& image,
                             RsGxsMessageId& postId,
-                            std::string& error_message)
+                            std::string& error_message,
+                            const RsGxsMessageId& origPostId)
 {
     // check boardId
 
@@ -752,8 +753,43 @@ bool p3Posted::createPostV2(const RsGxsGroupId& boardId,
         return false;
     }
 
+    // If origPostId is supplied, this is an edit of an already existing post.
+    // We reuse the same mOrigMsgId chain used elsewhere in GXS (channels,
+    // wikis) so that all versions of the post can be tracked and only the
+    // latest one is displayed.
+
+    RsGxsMessageId top_level_parent; // left blank intentionally for new posts
+
+    if(!origPostId.isNull())
+    {
+        std::set<RsGxsMessageId> s({ origPostId });
+        std::vector<RsPostedPost> posts;
+        std::vector<RsGxsComment> comments;
+        std::vector<RsGxsVote> votes;
+
+        if(!getBoardContent(boardId,s,posts,comments,votes) || posts.size()!=1)
+        {
+            error_message = "You cannot edit post " + origPostId.toStdString()
+                    + " of board with Id " + boardId.toStdString()
+                    + ": this post does not exist locally!";
+            RsErr() << error_message;
+            return false;
+        }
+
+        // All post versions should have the same mOrigMsgId, so we copy that
+        // of the post we're editing. The edited post may not have an
+        // original post id if it is itself the first version. In this case,
+        // the top_level_parent is set to be the id of the edited post.
+
+        top_level_parent = posts[0].mMeta.mOrigMsgId;
+
+        if(top_level_parent.isNull())
+            top_level_parent = origPostId;
+    }
+
     RsPostedPost post;
     post.mMeta.mGroupId = boardId;
+    post.mMeta.mOrigMsgId = top_level_parent;
     post.mLink = link.toString();
     post.mImage = image;
     post.mNotes = notes;

--- a/src/services/p3posted.h
+++ b/src/services/p3posted.h
@@ -97,7 +97,8 @@ virtual void receiveHelperChanges(std::vector<RsGxsNotify*>& changes)
                       const RsGxsId& authorId,
                       const RsGxsImage& image,
                       RsGxsMessageId& postId,
-                      std::string& error_message) override;
+                      std::string& error_message,
+                      const RsGxsMessageId& origPostId = RsGxsMessageId()) override;
 
     bool voteForPost(const RsGxsGroupId& boardId,
                      const RsGxsMessageId& postMsgId,


### PR DESCRIPTION
Companion PR to a matching RetroShare/RetroShare GUI PR, implementing the two libretroshare-side todos of the "[Qt] Boards improvements (alias Reddit clone)" issue (gitpay.me task 1474).

1. Edit posts by admin: createPostV2() gains an origPostId parameter. When set, the new post reuses the edited post's mOrigMsgId chain (same mechanism p3GxsChannels::createPostV2 already uses), so it's treated as a revision instead of a brand new post.
2. Stick/pin posts: RsPostedGroup gains mPinnedPosts (an RsTlvGxsMsgIdSet), mirroring the field forums already have on RsGxsForumGroup. Toggling it is done through the existing generic updateGroup() API, same as forums do via rsGxsForums->updateGroup(). p3PostBase::notifyChanges() now diffs the pinned-post set on group updates and emits a new PINNED_POSTS_CHANGED event, mirroring the moderator-list diffing already done for forums.
Please note: I don't have a full RetroShare build environment (Qt5/OpenPGP-SDK/etc.) available where I wrote this, so this has not been compiled or run. The code follows the existing patterns in p3GxsChannels/p3GxsForums closely, but please review carefully and let me know if anything needs adjusting before merge.