### PR TITLE
fix(peermgr): default SSL-only friends to RS_NODE_PERM_NONE

### DIFF
--- a/src/pqi/p3peermgr.cc
+++ b/src/pqi/p3peermgr.cc
@@ -1185,6 +1185,19 @@ bool p3PeerMgrIMPL::addSslOnlyFriend( const RsPeerId& sslId, const RsPgpId& pgp_
 	{ RS_STACK_MUTEX(mPeerMtx);
 		mFriendList[sslId] = pstate;
 		mStatusChanged = true;
+
+		/* Establish default (empty) service permissions for this PGP id if none
+		 * exist yet. This is essential: addSslOnlyFriend() is the entry point
+		 * used by short invites (webui, mobile, QR code...) and, unlike
+		 * addFriend(), it would otherwise leave mFriendsPermissionFlags without
+		 * an entry for this friend. Later on, gossip discovery and loadList call
+		 * addFriend() with the RS_NODE_PERM_ALL "keep the existing flags" mask,
+		 * relying on the per-friend entry to reduce it (service_flags &= entry).
+		 * With no entry that mask is written verbatim, silently granting the peer
+		 * DIRECT_DL | ALLOW_PUSH | REQUIRE_WL. Registering RS_NODE_PERM_NONE here
+		 * makes the mask a no-op and matches the default of GUI-added friends. */
+		if(mFriendsPermissionFlags.find(pgp_id) == mFriendsPermissionFlags.end())
+			mFriendsPermissionFlags[pgp_id] = RS_NODE_PERM_NONE;
 	} // RS_STACK_MUTEX(mPeerMtx);
 
     IndicateConfigChanged(RsConfigMgr::CheckPriority::SAVE_NOW);


### PR DESCRIPTION
fix(peermgr): default SSL-only friends to RS_NODE_PERM_NONE

addSslOnlyFriend() registers a friend without creating an entry in mFriendsPermissionFlags. This is the path taken by every short-invite add (webui, mobile, QR code). Later, gossip discovery (p3gossipdiscovery.cc) and loadList() call addFriend() with the RS_NODE_PERM_ALL "keep existing flags" mask, which is only reduced (service_flags &= entry) when a per-friend entry already exists.

For SSL-only friends no entry exists, so the RS_NODE_PERM_ALL mask is written verbatim and persisted, silently granting the peer DIRECT_DL | ALLOW_PUSH | REQUIRE_WL. The stray REQUIRE_WL then makes incoming connections from non-whitelisted addresses get refused (NOT_WHITELISTED) in pqissl::accept_locked(), spamming the log with "This should never happen at this point!" stack traces.

GUI-added friends are unaffected because addFriend() always writes an entry (RS_NODE_PERM_DEFAULT). Establish the same default here so the downstream mask stays a no-op.