### PR TITLE
fix(events): don't warn/stacktrace on a valid pre-generated handler id

### DIFF
--- a/src/services/rseventsservice.cc
+++ b/src/services/rseventsservice.cc
@@ -138,8 +138,25 @@ std::error_condition RsEventsService::registerEventsHandler(
         hId = generateUniqueHandlerId_unlocked();
     else
     {
-        print_stacktrace();
-        RsWarn() << "Overriding an existing error handler ID with a new callback. This is very unexpected. Make sure you know what you are doing." ;
+        /* A non-zero hId is a legitimate, documented use case: the caller may
+         * provide an id previously obtained from generateUniqueHandlerId() (see
+         * registerEventsHandler() doc in rsevents.h). This is exactly what the
+         * JSON API event-stream wrapper does, because its SSE callbacks capture
+         * the id in order to unregister themselves later. Only a hId that is
+         * actually already registered is a true override worth reporting. */
+        bool alreadyRegistered = false;
+        for(const auto& handlerMap : mHandlerMaps)
+            if(handlerMap.find(hId) != handlerMap.end())
+            {
+                alreadyRegistered = true;
+                break;
+            }
+
+        if(alreadyRegistered)
+        {
+            print_stacktrace();
+            RsWarn() << "Overriding an existing event handler ID with a new callback. This is very unexpected. Make sure you know what you are doing." ;
+        }
     }
 
 	mHandlerMaps[static_cast<std::size_t>(eventType)][hId] = multiCallback;


### PR DESCRIPTION
fix(events): don't warn/stacktrace on a valid pre-generated handler id

registerEventsHandler() documents (rsevents.h) that the caller may pass an hId previously obtained from generateUniqueHandlerId(). The JSON API event-stream wrapper (jsonapi.cpp) does exactly this: it pre-generates the id so its SSE callbacks can capture it to unregister themselves, then passes it to registerEventsHandler().

The implementation treated any non-zero hId as an override, calling print_stacktrace() + "Overriding an existing error handler ID ... very unexpected". So every event-stream registration (every webui/mobile connection, plus each 5s reconnect and each 1MB queue restart) dumped a bogus stack trace to the log, contradicting the API's own contract.

Only warn when the hId is actually already present in the handler maps, i.e. a real override. A freshly generated id never is (ids are monotonic), so the false positive is gone while genuine accidental id reuse is still reported. Only jsonapi.cpp pre-generates ids; every other caller passes 0, so behaviour there is unchanged.