### PR TITLE
Fix to start webservice on Android

### DIFF
--- a/src/rs_android/retroshareserviceandroid.cpp
+++ b/src/rs_android/retroshareserviceandroid.cpp
@@ -74,6 +74,10 @@ RetroShareServiceAndroid::start(
 		return jni::Make<ErrorConditionWrap>(env, std::errc::no_child_process);
 	}
 
+#ifdef RS_JSONAPI
+	RsInit::startupWebServices(conf, true);
+#endif
+
 	return jni::Make<ErrorConditionWrap>(env, std::error_condition());
 }
 

--- a/src/rsserver/p3face-config.cc
+++ b/src/rsserver/p3face-config.cc
@@ -104,7 +104,10 @@ void RsServer::rsGlobalShutDown()
 	fullstop();
 
 #ifdef RS_JSONAPI
-	rsJsonApi->fullstop();
+	if (rsJsonApi != nullptr)
+	{
+		rsJsonApi->fullstop();
+	}
 #endif
 
 	AuthPGP::exit();

--- a/src/rsserver/p3face-config.cc
+++ b/src/rsserver/p3face-config.cc
@@ -104,10 +104,7 @@ void RsServer::rsGlobalShutDown()
 	fullstop();
 
 #ifdef RS_JSONAPI
-	if (rsJsonApi != nullptr)
-	{
-		rsJsonApi->fullstop();
-	}
+	if(rsJsonApi) rsJsonApi->fullstop();
 #endif
 
 	AuthPGP::exit();


### PR DESCRIPTION
Fix to not crash on Android shutdown

# Analysis of RetroShare Service Startup Failure on Android

## Summary of Findings
When upgrading `libretroshare` from the 2022 version (`f343db4c`) to the new CMake-based version (`2ed36b6f`), the Android service successfully runs, but the JSON API server does not listen. Consequently, the Flutter frontend waits indefinitely on the "Starting Retroshare Service" screen because it cannot connect to the backend REST API.

---

## Root Cause

### 1. Old Implementation (2022 - `f343db4c`)
In the old version of `libretroshare`, the `JsonApiServer` (responsible for handling REST API requests) was instantiated and started directly inside the core initialization function `RsInit::InitRetroShare` in [rsserver/rsinit.cc](file:///src/rsserver/rsinit.cc):

```cpp
# ifdef RS_JSONAPI
	JsonApiServer* jas = new JsonApiServer();
	jas->setListeningPort(conf.jsonApiPort);
	jas->setBindingAddress(conf.jsonApiBindAddress);

	if(conf.jsonApiPort != 0) jas->restart();

	rsJsonApi = jas;
# endif
```

Since the Android JNI wrapper [retroshareserviceandroid.cpp](file:///src/rs_android/retroshareserviceandroid.cpp) invoked `RsInit::InitRetroShare(conf)`, the JSON API server started automatically during startup.

### 2. New Implementation (2026 - `2ed36b6f`)
In the refactored version of the library, this initialization logic was extracted from `RsInit::InitRetroShare` and moved into a new static method:

```cpp
void RsInit::startupWebServices(const RsConfigOptions& conf, bool force_start_jsonapi);
```

While desktop components and other daemons were updated to call `RsInit::startupWebServices` after initializing, the **Android JNI entry point (`RetroShareServiceAndroid::start`) was never updated**. It still only calls `RsInit::InitRetroShare(conf)`.

Because `RsInit::startupWebServices` is never called:
- `rsJsonApi` remains `nullptr` (uninitialized).
- The REST API listener is never spawned on port `9092`.
- Attempting to shut down the service triggers a SIGSEGV/crash if the core code tries to call `rsJsonApi->fullstop()` without a `nullptr` check.

---

## Proposed Solution

To resolve this issue, the Android JNI wrapper must invoke `RsInit::startupWebServices` right after a successful initialization.

### Patch for `retroshareserviceandroid.cpp`

Apply the following change in the `libretroshare` repository:

```diff
diff --git a/src/rs_android/retroshareserviceandroid.cpp b/src/rs_android/retroshareserviceandroid.cpp
index d87028b..c16f6b9 100644
--- a/src/rs_android/retroshareserviceandroid.cpp
+++ b/src/rs_android/retroshareserviceandroid.cpp
@@ -77,6 +77,10 @@ RetroShareServiceAndroid::start(
 		RS_ERR("Retroshare core initalization failed with: ", initResult);
 		return jni::Make<ErrorConditionWrap>(env, std::errc::no_child_process);
 	}
 
+#ifdef RS_JSONAPI
+	RsInit::startupWebServices(conf, true);
+#endif
+
 	return jni::Make<ErrorConditionWrap>(env, std::error_condition());
 }
```

### Safety Check for Shutdown
Ensure that the global shutdown routine (likely in `pqi` or `rsserver`) checks that `rsJsonApi` is not `nullptr` before attempting to shut it down:

```cpp
#ifdef RS_JSONAPI
	if (rsJsonApi != nullptr)
	{
		rsJsonApi->fullstop();
	}
#endif
```

