### PR TITLE
Fix auth token issue on Android

### DIFF
--- a/src/rsserver/rsinit.cc
+++ b/src/rsserver/rsinit.cc
@@ -2148,7 +2148,15 @@ RsInit::LoadCertificateStatus RsLoginHelper::attemptLogin(const RsPeerId& accoun
                 return RsInit::ERR_CANNOT_CONFIGURE_TOR;
 
         if(ret == RsInit::OK && RsControl::instance()->StartupRetroShare() == 1)
+        {
+#ifdef RS_JSONAPI
+            if(rsJsonApi)
+            {
+                rsJsonApi->authorizeUser(account.toStdString(), password);
+            }
+#endif
             return RsInit::OK;
+        }
 
         return ret;
     }


### PR DESCRIPTION


The login error you are seeing (**`Authentication Failed - AUTHTOKEN FAILED`**) with the `2005 Unknown API user` log message occurs because the RetroShare JSON API server has not authorized your user credentials. 

### Why the error happens

1. **JSON API Authentication**: 
   When you unlock/login to your RetroShare profile, the Flutter application (`rs-mobile`) communicates with the local RetroShare background service using HTTP JSON API requests (typically on localhost port `9092`). These API methods require Basic Authentication.
2. **Empty Authorized Tokens for Imported/Existing Accounts**:
   * **During Signup (Create Account)**: The app calls the API method `/rsLoginHelper/createLocationV2`, which registers the newly created username (`apiUser`) and password with the JSON API server using `authorizeUser`. This is saved in the profile's `jsonapi.cfg` config file.
   * **During Import or Login to Existing Accounts**: When you import an existing profile (via `/rsLoginHelper/importLocation` or `importIdentityAndCreateLocation`), or log in to a profile that was created on another device (e.g., desktop), **no JSON API user is ever authorized**. As a result, the profile's `jsonapi.cfg` contains no credentials.
3. **Authentication Failure at Login**:
   Once the profile is unlocked, the Flutter app's [auth.dart](file:///C:/Users/Ozan/Documents/GitHub/rs-mobile/lib/provider/auth.dart#L64-L90) calls `getinitializeAuth(...)` to verify and cache the auth token. It tries to authenticate using:
   * The `locationId` (SSL ID)
   * The `pgpName` (username)
   * The `locationName` (node name)

   Since the imported profile has no authorized users, the JSON API server blocks these requests and returns:
   `RsJsonApiErrorNum::UNKNOWN_API_USER = 2005` (category `"RetroShare JSON API"`).
   
   Because all authentication attempts fail, `getinitializeAuth(...)` returns `false` and throws `AUTHTOKEN FAILED`, causing the error dialog to appear.

---

### How to Fix it

To resolve this permanently, we can modify the RetroShare C++ core service so that **any successful profile unlock automatically authorizes the API user**.

We can edit the `attemptLogin` method in [rsinit.cc](file:///C:/Users/Username/Documents/GitHub/RetroShare/libretroshare/src/rsserver/rsinit.cc#L2124-L2156) (or the corresponding file in `RetroShare`) to authorize the location ID when a login succeeds:

```diff
        if(ret == RsInit::OK && RsControl::instance()->StartupRetroShare() == 1)
+       {
+           if(rsJsonApi)
+           {
+               rsJsonApi->authorizeUser(account.toStdString(), password);
+           }
            return RsInit::OK;
+       }
```

This way, whenever you log in with your profile password, your location ID will be automatically authorized for the JSON API server.



