### PR TITLE
fix(pgp): throttle trust-db rewrite in RNPPGPHandler::locked_timeStampKey

### DIFF
--- a/src/pgp/rnppgphandler.cc
+++ b/src/pgp/rnppgphandler.cc
@@ -262,8 +262,23 @@ ops_keyring_t *OpenPGPSDKHandler::allocateOPSKeyring()
 
 void RNPPGPHandler::locked_timeStampKey(const RsPgpId& key_id)
 {
-    _public_keyring_map[key_id]._time_stamp = time(nullptr);
-    _trustdb_changed = true;
+    rstime_t now = time(nullptr);
+    _public_keyring_map[key_id]._time_stamp = now;
+
+    // Only flag the trust database for rewrite once per hour. This function is
+    // called on every PGP key usage (e.g. VerifySignBin(), which runs on every
+    // GXS identity validation and every connection). Flagging _trustdb_changed
+    // on each call caused the whole private trust database (thousands of
+    // packets) to be rewritten and re-read every few seconds. Updating the
+    // in-memory usage timestamp on every call is cheap and stays; only the
+    // on-disk sync is throttled. OpenPGPSDKHandler throttles the same way (see
+    // openpgpsdkhandler.cc); the rnp port had dropped it.
+    static rstime_t last_trustdb_update_because_of_stamp = 0;
+    if(now > last_trustdb_update_because_of_stamp + 3600)
+    {
+        _trustdb_changed = true;
+        last_trustdb_update_because_of_stamp = now;
+    }
 }
 
 bool rnp_get_passphrase_cb(rnp_ffi_t        /* ffi */,


### PR DESCRIPTION
fix(pgp): throttle trust-db rewrite in RNPPGPHandler::locked_timeStampKey

locked_timeStampKey() is called on every PGP key usage, notably from RNPPGPHandler::VerifySignBin() which runs on every GXS identity validation (p3IdService::pgphash_process -> checkId) and every connection. It updated the key's in-memory usage timestamp AND flagged _trustdb_changed on every call.

Because of that, the whole private trust database was rewritten by locked_syncTrustDatabase() on essentially every AuthGPG tick, its file mtime bumped, and then re-read in full (thousands of trust packets) a few seconds later. On a node with many keys this produced a "Detected change on disk of trust database" + full reload every ~10-30s indefinitely (hundreds of times per session), wasting CPU and flooding the log.

OpenPGPSDKHandler already throttles this exact update to once per hour; the rnp port had dropped the throttle. Restore it: keep updating the in-memory _time_stamp on every call (cheap), but only set _trustdb_changed at most once per hour. The on-disk trust database is then rewritten ~once per hour instead of constantly.