### PR TITLE
fix(pqi): don't restart an already-running peer streamer thread

### DIFF
--- a/src/pqi/pqiperson.cc
+++ b/src/pqi/pqiperson.cc
@@ -344,7 +344,14 @@ int pqiperson::handleNotifyEvent_locked(NetInterface *ni, int newState,
 			inConnectAttempt = false;
 
 			// STARTUP THREAD
-			activepqi->start("pqi " + PeerId().toStdString().substr(0, 11));
+			// On a reconnection over the same interface, activepqi's streamer
+			// thread is still running: only start it when it isn't, otherwise
+			// RsThread::start() logs "attempt to start already running thread"
+			// plus a stack trace on every such reconnection. The already-running
+			// thread keeps serving the (switched-over) connection, so this is
+			// purely noise removal and does not change behaviour.
+			if(!activepqi->isRunning())
+				activepqi->start("pqi " + PeerId().toStdString().substr(0, 11));
 
 			// reset all other children (clear up long UDP attempt)
 			for(it = kids.begin(); it != kids.end(); ++it)


### PR DESCRIPTION
fix(pqi): don't restart an already-running peer streamer thread

pqiperson::handleNotifyEvent_locked() unconditionally calls activepqi->start() on CONNECT_SUCCESS. When a peer reconnects over the same interface, the streamer thread (pqithreadstreamer, an RsThread) is still running, so RsThread::start() hits its "already running" guard and logs `attempt to start already running thread: pqi <peer>` followed by a full stack trace, on every such reconnection.

This is purely noise: start() was already failing (returning false), so the thread was never actually restarted; pqissl switches the socket over underneath the running streamer. Guard the call with RsThread::isRunning() so it is only (re)started when actually stopped. Behaviour is unchanged; only the spurious error + stack trace are gone.