### PR TITLE
Added auth token fix for rs mobile

### DIFF
--- a/src/jsonapi/jsonapi.cpp
+++ b/src/jsonapi/jsonapi.cpp
@@ -283,6 +283,65 @@ JsonApiServer::JsonApiServer(): configMutex("JsonApiServer config"),
 		} );
 	}, false);
 
+	registerHandler("/rsLoginHelper/attemptLogin",
+	                [this](const std::shared_ptr<rb::Session> session)
+	{
+		auto reqSize = session->get_request()->get_header("Content-Length", 0);
+		session->fetch( static_cast<size_t>(reqSize), [this](
+		                const std::shared_ptr<rb::Session> session,
+		                const rb::Bytes& body )
+		{
+			INITIALIZE_API_CALL_JSON_CONTEXT;
+
+			RsPeerId account;
+			std::string password;
+
+			// JSON API only
+			std::string apiUser;
+			std::string apiPass;
+
+			// deserialize input parameters from JSON
+			{
+				RsGenericSerializer::SerializeContext& ctx(cReq);
+				RsGenericSerializer::SerializeJob j(RsGenericSerializer::FROM_JSON);
+				RS_SERIAL_PROCESS(account);
+				RS_SERIAL_PROCESS(password);
+
+				// JSON API only
+				RS_SERIAL_PROCESS(apiUser);
+				RS_SERIAL_PROCESS(apiPass);
+			}
+
+			RsInit::LoadCertificateStatus retval;
+
+			if(!apiUser.empty() && badApiCredientalsFormat(apiUser, apiPass))
+			{
+				retval = RsInit::LoadCertificateStatus::ERR_UNKNOWN;
+			}
+			else
+			{
+				// Call retroshare C++ API
+				retval = rsLoginHelper->attemptLogin(account, password);
+
+				// If login succeeded and custom API credentials were provided, authorize them!
+				if(retval == RsInit::OK && !apiUser.empty())
+				{
+					authorizeUser(apiUser, apiPass);
+				}
+			}
+
+			// serialize out parameters and return value to JSON
+			{
+				RsGenericSerializer::SerializeContext& ctx(cAns);
+				RsGenericSerializer::SerializeJob j(RsGenericSerializer::TO_JSON);
+				RS_SERIAL_PROCESS(retval);
+			}
+
+			// return them to the API caller
+			DEFAULT_API_CALL_JSON_RETURN(rb::OK);
+		} );
+	}, false);
+
 	registerHandler("/rsControl/rsGlobalShutDown",
 	                [](const std::shared_ptr<rb::Session> session)
 	{

--- a/src/retroshare/rsinit.h
+++ b/src/retroshare/rsinit.h
@@ -419,9 +419,17 @@ public:
 
 	/**
 	 * @brief Normal way to attempt login
-	 * @jsonapi{development,unauthenticated}
+	 * @jsonapi{development,manualwrapper}
 	 * @param[in] account Id of the account to which attempt login
 	 * @param[in] password Password for the given account
+	 * param[in] apiUser (JSON API only) string containing username for JSON API
+	 *	so it can be later used to authenticate JSON API calls. It is passed
+	 *	down to @see RsJsonApi::authorizeUser under the hood.
+	 * param[in] apiPass (JSON API only) string containing password for JSON API
+	 *	so it can be later used to authenticate JSON API calls. It is passed
+	 *	down to @see RsJsonApi::authorizeUser under the hood.
+	 *	To improve security we strongly advise to not use the same as the
+	 *	password used for the PGP key.
 	 * @return RsInit::OK if login attempt success, error code otherwhise
 	 */
 	RsInit::LoadCertificateStatus attemptLogin(

--- a/src/retroshare/rsinit.h
+++ b/src/retroshare/rsinit.h
@@ -419,7 +419,7 @@ public:
 
 	/**
 	 * @brief Normal way to attempt login
-	 * @jsonapi{development,manualwrapper}
+	 * @jsonapi{development,manualwrapper,unauthenticated}
 	 * @param[in] account Id of the account to which attempt login
 	 * @param[in] password Password for the given account
 	 * param[in] apiUser (JSON API only) string containing username for JSON API

--- a/src/rsserver/rsinit.cc
+++ b/src/rsserver/rsinit.cc
@@ -1345,6 +1345,17 @@ int RsServer::StartupRetroShare()
 	//
 	mPluginsManager->loadPlugins(programatically_inserted_plugins) ;
 
+#ifdef RS_JSONAPI
+	if (rsJsonApi)
+	{
+		p3ConfigMgr *cfgmgr = dynamic_cast<p3ConfigMgr*>(mConfigMgr);
+		if (cfgmgr != nullptr)
+		{
+			rsJsonApi->connectToConfigManager(*cfgmgr);
+		}
+	}
+#endif
+
     	/**** Reputation system ****/
 
     	p3GxsReputation *mReputations = new p3GxsReputation(mLinkMgr) ;


### PR DESCRIPTION
# Walkthrough - Secure API Token Authentication

We have designed and implemented a safer authentication mechanism for RetroShare's JSON API. The PGP/profile password is no longer transmitted in the Authorization headers of REST requests, nor is it registered as the API token. Instead, we dynamically derive a secure API token client-side and authorize it upon login.

---

## Changes

### 1. C++ Core (libretroshare)
- **[rsinit.h](file:///C:/Users/Ozan/Documents/GitHub/RetroShare/libretroshare/src/retroshare/rsinit.h)**: Marked `attemptLogin` as `manualwrapper` to exclude it from automatic API wrapper generation.
- **[jsonapi.cpp](file:///C:/Users/Ozan/Documents/GitHub/RetroShare/libretroshare/src/jsonapi/jsonapi.cpp)**: Implemented a manual wrapper for `/rsLoginHelper/attemptLogin` that deserializes optional `apiUser` and `apiPass` fields, calls `attemptLogin`, and registers the client's custom credentials using `authorizeUser(apiUser, apiPass)` if the login is successful.


### 2. Dart API Wrapper (Retroshare-Wrapper)
- **[retroshare.dart](file:///C:/Users/Ozan/Documents/GitHub/Retroshare-Wrapper/lib/src/retroshare.dart)**: Updated `requestLogIn` and `requestAccountCreation` to accept optional `apiUser` and `apiPass` arguments and include them in the request body parameters.

### 3. Mobile Client (rs-mobile)
- **[pubspec.yaml](file:///C:/Users/Ozan/Documents/GitHub/rs-mobile/pubspec.yaml)**:
  - Added the `crypto` package dependency.
- **[auth.dart](file:///auth.dart)**:
  - Added `deriveApiToken` helper function using `sha256(locationId:password)` to dynamically compute secure API credentials.
  - Modified `getinitializeAuth` to verify credentials using `deriveApiToken`.
  - Updated `login` and `signup` methods to derive the secure credentials and pass them during registration/login calls.

---

## Verification Results
- All components compiled successfully with zero errors.
- Dependencies were resolved correctly with `flutter pub get`.
