### PR TITLE
fixing the "(EE) Trying to display a peer that is not a friend" bug.

### DIFF
--- a/src/pqi/p3peermgr.cc
+++ b/src/pqi/p3peermgr.cc
@@ -2710,7 +2710,7 @@ bool  p3PeerMgrIMPL::loadList(std::list<RsItem *>& load)
 
         // Also filter out profiles in groups that are not friends. Normally this shouldn't be needed, but it's a precaution
 
-        for(auto group_pair:groupList)
+        for(auto& group_pair:groupList)
         {
             for(auto profileIdIt(group_pair.second.peerIds.begin());profileIdIt!=group_pair.second.peerIds.end();)
                 if(AuthPGP::isPGPAccepted(*profileIdIt) || *profileIdIt == AuthPGP::getPgpOwnId())


### PR DESCRIPTION
The iterator in p3peermgr.cc:2713 was just doing a copy of the list of profiles in a group before filtering deleted friends from it. The original list was therefore unalterated.