### PR TITLE
Auto-detect botan-3 vs botan-2 for librnp linking on Unix

### DIFF
--- a/src/use_libretroshare.pri
+++ b/src/use_libretroshare.pri
@@ -63,8 +63,17 @@ rs_rnplib {
         # Windows msys2
         LIBRNP_LIBS *= -lbotan-3
     } else {
-        # This is the case for macOS and other Unix-like systems
-        LIBRNP_LIBS *= -lbotan-2
+        # macOS and other Unix-like systems: prefer botan-3 when available,
+        # since botan-2 reached end of life in 2024 and has since been
+        # dropped by some distributions (e.g. Gentoo). Fall back to botan-2
+        # for systems that don't have botan-3 packaged yet (e.g. Ubuntu
+        # 24.04), matching what librnp's own CMake build already detects.
+        BOTAN3_OK = $$system(pkg-config --exists botan-3 && echo yes)
+        isEmpty(BOTAN3_OK) {
+            LIBRNP_LIBS *= -lbotan-2
+        } else {
+            LIBRNP_LIBS *= -lbotan-3
+        }
     }
 
     win32-g++|win32-clang-g++ {


### PR DESCRIPTION
## Summary
botan-2 reached end of life in 2024 and has since been dropped by some distributions (Gentoo removed it entirely), breaking the build with `-lbotan-2 cant be found` wherever only botan-3 is installed.

`librnp`'s own CMake build (`supportlibs/librnp`) already auto-detects and adapts to whichever botan version is available (`FindBotan.cmake` searches for both, and `CRYPTO_BACKEND_BOTAN3` gets set automatically based on the detected version). The qmake-level linker flag for RetroShare's own binaries did not follow suit — it unconditionally hardcoded `-lbotan-2` for all non-Windows platforms in `src/use_libretroshare.pri`, so even when librnp itself built fine against botan-3, the final link step still failed looking for a botan-2 that no longer exists.

This detects via `pkg-config` which version is actually available, preferring botan-3 and falling back to botan-2 — mirroring the existing `SQLCIPHER_OK` detection pattern already used elsewhere in the same file.

Fixes the build failure reported in https://github.com/RetroShare/RetroShare/issues/3190

## Test plan
- [x] Ran `qmake` for `retroshare-service.pro` with `CONFIG+=rs_rnplib` on Ubuntu 24.04 (where only botan-2 is packaged, botan-3 is not): parses cleanly, generated `Makefile` still links `-lbotan-2` — confirms no regression for systems without botan-3
- [x] Confirmed via `pkg-config --exists botan-3`/`botan-2` on this host that detection logic resolves to the expected fallback branch
- [ ] Not able to verify the botan-3 branch end-to-end (no botan-3 package available on this host) — would appreciate a check from someone on Gentoo/Arch where botan-3 is packaged