### PR TITLE
fix/close the incoming listener first at shutdown

### DIFF
--- a/src/pqi/pqipersongrp.cc
+++ b/src/pqi/pqipersongrp.cc
@@ -257,6 +257,21 @@ bool    pqipersongrp::resetListener(const struct sockaddr_storage &local)
 	return 1;
 }
 
+/* Close the incoming-connection socket without recreating it. Called at the very
+ * start of shutdown so that no new peer can be authenticated and handed a per-peer
+ * streamer thread while the rest of the engine is being torn down. Unlike
+ * resetListener() this does NOT setuplisten() again: once active is cleared,
+ * acceptconnection()/continueaccepts() become no-ops on every subsequent tick(). */
+int     pqipersongrp::stopListener()
+{
+	RsStackMutex stack(pqilMtx); /******* LOCKED MUTEX **********/
+
+	if (pqil != NULL)
+		pqil -> resetlisten();
+
+	return 1;
+}
+
 void    pqipersongrp::statusChange(const std::list<pqipeer> &plist)
 {
 

--- a/src/pqi/pqipersongrp.h
+++ b/src/pqi/pqipersongrp.h
@@ -50,8 +50,9 @@ class pqipersongrp: public pqihandler, public pqiMonitor, public p3ServiceServer
 	/*************************** Setup *************************/
 	/* pqilistener */
 
-virtual bool resetListener(const struct sockaddr_storage &local); // overloaded from pqiNetListener 
-int     init_listener(); 
+virtual bool resetListener(const struct sockaddr_storage &local); // overloaded from pqiNetListener
+int     init_listener();
+int     stopListener();  /* close the incoming-connection socket (used at shutdown) */
 
 	/*************** pqiMonitor callback ***********************/
 virtual void    statusChange(const std::list<pqipeer> &plist);

--- a/src/rsserver/p3face-config.cc
+++ b/src/rsserver/p3face-config.cc
@@ -86,6 +86,18 @@ void RsServer::rsGlobalShutDown()
 
 	if(wasReady)
 	{
+		/* Close the incoming-connection listener FIRST, before anything else.
+		 * The steps below (config save, plugin stop, UPnP teardown and above all
+		 * the auto-proxy shutdown) can take >20s, during which the RsServer tick
+		 * thread is still alive and keeps ticking the listener. Left open, it goes
+		 * on accepting TCP connections and completing full SSL+PGP handshakes right
+		 * up to the last second before the databases close -- creating per-peer
+		 * state (sockets, streamer threads) that races the teardown of the static
+		 * SmallObject allocator. Closing the accept socket now admits no new peer
+		 * for the whole shutdown; fullstopAllThreads() below then drains the
+		 * already-connected ones. */
+		if(pqih) pqih->stopListener();
+
 		// save configuration before exit
 		ConfigFinalSave();
 


### PR DESCRIPTION
fix/close the incoming listener first at shutdown

At shutdown, the pqissllistener accept socket stays open too long. It has no thread of its own. The RsServer tick thread drives it. That thread only stops at fullstop() — after config save, plugin stop, UPnP and the auto-proxy wait. That sequence often takes 20 s+.

During that whole window, RetroShare keeps accepting connections. It completes full SSL+PGP handshakes. Logs show a new peer authenticated about one second before the databases close. Each late peer creates per-peer state (sockets, streamer threads). That races the teardown of static objects at process exit. It is the same problem fullstopAllThreads() guards against, but on the admission side.

Fix: add pqipersongrp::stopListener(). It closes the accept socket via pqil->resetlisten() under pqilMtx, without recreating it. Unlike resetListener(), it does not call setuplisten() again. Once active is cleared, acceptconnection()/continueaccepts() are no-ops on every tick. It runs as the first step of rsGlobalShutDown(). No new peer is admitted during teardown. Already-connected peers are still drained by fullstopAllThreads(). Only inbound admission changes — outbound connections are untouched.

Testing: compared shutdown logs before/after (Linux, Qt5). Inbound connections accepted during shutdown: 3 → 0. Clean exit in both cases (all DBs closed, no crash).