### PR TITLE
Fix/remote dir cleanup delay

### DIFF
--- a/src/file_sharing/directory_storage.cc
+++ b/src/file_sharing/directory_storage.cc
@@ -138,6 +138,16 @@ bool DirectoryStorage::getDirectoryUpdateTime   (EntryIndex index,rstime_t& upda
 bool DirectoryStorage::getDirectoryRecursModTime(EntryIndex index,rstime_t& rec_md_TS) const { RS_STACK_MUTEX(mDirStorageMtx) ; return mFileHierarchy->getTS(index,rec_md_TS,&InternalFileHierarchyStorage::DirEntry::dir_most_recent_time); }
 bool DirectoryStorage::getDirectoryLocalModTime (EntryIndex index,rstime_t& loc_md_TS) const { RS_STACK_MUTEX(mDirStorageMtx) ; return mFileHierarchy->getTS(index,loc_md_TS,&InternalFileHierarchyStorage::DirEntry::dir_modtime         ); }
 
+bool DirectoryStorage::getDirectoryCumulatedFileCount(EntryIndex index,uint32_t& file_count) const
+{
+    RS_STACK_MUTEX(mDirStorageMtx) ;
+    const InternalFileHierarchyStorage::DirEntry *d = mFileHierarchy->getDirEntry(index) ;
+    if(d == nullptr)
+        return false ;
+    file_count = d->dir_cumulated_files ;
+    return true ;
+}
+
 bool DirectoryStorage::setDirectoryUpdateTime   (EntryIndex index,rstime_t  update_TS) { RS_STACK_MUTEX(mDirStorageMtx) ; return mFileHierarchy->setTS(index,update_TS,&InternalFileHierarchyStorage::DirEntry::dir_update_time     ); }
 bool DirectoryStorage::setDirectoryRecursModTime(EntryIndex index,rstime_t  rec_md_TS) { RS_STACK_MUTEX(mDirStorageMtx) ; return mFileHierarchy->setTS(index,rec_md_TS,&InternalFileHierarchyStorage::DirEntry::dir_most_recent_time); }
 bool DirectoryStorage::setDirectoryLocalModTime (EntryIndex index,rstime_t  loc_md_TS) { RS_STACK_MUTEX(mDirStorageMtx) ; return mFileHierarchy->setTS(index,loc_md_TS,&InternalFileHierarchyStorage::DirEntry::dir_modtime         ); }

--- a/src/file_sharing/directory_storage.h
+++ b/src/file_sharing/directory_storage.h
@@ -56,6 +56,7 @@ class DirectoryStorage
         bool getDirectoryRecursModTime(EntryIndex index,rstime_t& recurs_max_modf_TS) const ;		// last modification time, computed recursively over all subfiles and directories
         bool getDirectoryLocalModTime (EntryIndex index,rstime_t& motime_TS) const ;				// last modification time for that index only
         bool getDirectoryUpdateTime   (EntryIndex index,rstime_t& update_TS) const ;				// last time the entry was updated. This is only used on the RemoteDirectoryStorage side.
+        bool getDirectoryCumulatedFileCount(EntryIndex index,uint32_t& file_count) const ;			// number of files, computed recursively over all subdirectories. Same "empty" notion as the UI.
 
         bool setDirectoryRecursModTime(EntryIndex index,rstime_t  recurs_max_modf_TS) ;
         bool setDirectoryLocalModTime (EntryIndex index,rstime_t  modtime_TS) ;

--- a/src/file_sharing/file_sharing_defaults.h
+++ b/src/file_sharing/file_sharing_defaults.h
@@ -27,8 +27,8 @@ static const uint32_t DELAY_BETWEEN_LOCAL_DIRECTORIES_TS_UPDATE =   20 ; // 20 s
 static const uint32_t DELAY_BETWEEN_REMOTE_DIRECTORIES_SWEEP    =   60 ; // 60 sec.
 static const uint32_t DELAY_BETWEEN_EXTRA_FILES_CACHE_UPDATES   =    2 ; //  2 sec.
 
-static const uint32_t DELAY_BEFORE_DELETE_NON_EMPTY_REMOTE_DIR  = 60*24*86400 ; // delete non empty remoe directories after 60 days of inactivity
-static const uint32_t DELAY_BEFORE_DELETE_EMPTY_REMOTE_DIR      =  5*24*86400 ; // delete empty remote directories after 5 days of inactivity
+static const uint32_t DELAY_BEFORE_DELETE_NON_EMPTY_REMOTE_DIR  = 60*86400 ; // delete non empty remote directories after 60 days of inactivity
+static const uint32_t DELAY_BEFORE_DELETE_EMPTY_REMOTE_DIR      =  5*86400 ; // delete empty remote directories after 5 days of inactivity
 
 static const std::string HASH_CACHE_DURATION_SS                 = "HASH_CACHE_DURATION" ;	             // key string to store hash remembering time
 static const std::string WATCH_FILE_DURATION_SS                 = "WATCH_FILES_DELAY" ;		             // key to store delay before re-checking for new files

--- a/src/file_sharing/p3filelists.cc
+++ b/src/file_sharing/p3filelists.cc
@@ -733,8 +733,14 @@ void p3FileDatabase::cleanup()
         for(uint32_t i=0;i<mRemoteDirectories.size();++i)
             if(mRemoteDirectories[i] != NULL)
             {
-                rstime_t recurs_mod_time ;
-                mRemoteDirectories[i]->getDirectoryRecursModTime(0,recurs_mod_time) ;
+                // "Empty" here means "shares no file", using the same signal as the GUI (cumulated file
+                // count at the root). A tree made of directories only (no files) has a non-zero recursive
+                // modification time, so testing that would keep such a peer on the 60-days timer even though
+                // the GUI shows it as "Empty". Counting files instead makes both agree.
+
+                uint32_t file_count = 0 ;
+                mRemoteDirectories[i]->getDirectoryCumulatedFileCount(0,file_count) ;
+                bool dir_is_empty = (file_count == 0) ;
 
                 rstime_t last_contact = 0 ;
                 RsPeerDetails pd ;
@@ -744,11 +750,11 @@ void p3FileDatabase::cleanup()
                 // We remove directories in the following situations:
                 //	- the peer is not a friend
                 //  - the dir list is non empty but the peer is offline since more than 60 days
-                //  - the dir list is empty and the peer is ffline since more than 5 days
+                //  - the dir list is empty and the peer is offline since more than 5 days
 
                 bool should_remove =  friend_set.find(mRemoteDirectories[i]->peerId()) == friend_set.end()
-                        			|| (recurs_mod_time == 0 && last_contact + DELAY_BEFORE_DELETE_EMPTY_REMOTE_DIR     < now )
-                        			|| (recurs_mod_time != 0 && last_contact + DELAY_BEFORE_DELETE_NON_EMPTY_REMOTE_DIR < now );
+                        			|| ( dir_is_empty && last_contact + DELAY_BEFORE_DELETE_EMPTY_REMOTE_DIR     < now )
+                        			|| (!dir_is_empty && last_contact + DELAY_BEFORE_DELETE_NON_EMPTY_REMOTE_DIR < now );
 
                 if(!should_remove)
                     continue ;

--- a/src/file_sharing/p3filelists.cc
+++ b/src/file_sharing/p3filelists.cc
@@ -739,7 +739,7 @@ void p3FileDatabase::cleanup()
                 // the GUI shows it as "Empty". Counting files instead makes both agree.
 
                 uint32_t file_count = 0 ;
-                mRemoteDirectories[i]->getDirectoryCumulatedFileCount(0,file_count) ;
+                mRemoteDirectories[i]->getDirectoryCumulatedFileCount(mRemoteDirectories[i]->root(),file_count) ;
                 bool dir_is_empty = (file_count == 0) ;
 
                 rstime_t last_contact = 0 ;


### PR DESCRIPTION
Fix/remote dir cleanup delay

p3FileDatabase::cleanup() never purges a friend's cached file list, even after months offline. Two fixes:

Delays off by 24× (file_sharing_defaults.h): 86400 is already a day, but the thresholds had an extra *24 → the "60 / 5 days" comments were really 1440 / 120 days. Dropped the *24.

"Empty" now matches the GUI: cleanup used getDirectoryRecursModTime()==0, so a folder-only tree (0 files) stayed on the 60-day timer while Friends Files shows it Empty. Now uses dir_cumulated_files==0 (new getDirectoryCumulatedFileCount()) → pruned on the 5-day timer.

Timer is keyed on lastcontact (real connect/disconnect, persisted), so reconnecting peers are unaffected.