### PR TITLE
implement persistent Ignore/Deny list with Names and PGP ID

### DIFF
--- a/src/pqi/authssl.cc
+++ b/src/pqi/authssl.cc
@@ -1353,6 +1353,8 @@ int AuthSSLimpl::VerifyX509Callback(int /*preverify_ok*/, X509_STORE_CTX* ctx)
 
 		RsInfo() << __PRETTY_FUNCTION__ << " " << errMsg << std::endl;
 
+
+
 		if(rsEvents && !isNotifyDenied(pgpId) && !isStringDenied(pgpId.toStdString()))
 		{
 			ev->mSslCn = sslCn;
@@ -1374,6 +1376,8 @@ int AuthSSLimpl::VerifyX509Callback(int /*preverify_ok*/, X509_STORE_CTX* ctx)
 		        "<<<";
 
 		RsInfo() << __PRETTY_FUNCTION__ << " " << errMsg << std::endl;
+
+
 
 		if(rsEvents && !isNotifyDenied(pgpId) && !isStringDenied(pgpId.toStdString()))
 		{
@@ -1433,6 +1437,8 @@ int AuthSSLimpl::VerifyX509Callback(int /*preverify_ok*/, X509_STORE_CTX* ctx)
 
 		RsInfo() << __PRETTY_FUNCTION__ << " " << errMsg << std::endl;
 
+
+
 		if(rsEvents && !isNotifyDenied(pgpId))
 		{
 			ev->mSslId = sslId;
@@ -1473,6 +1479,8 @@ int AuthSSLimpl::VerifyX509Callback(int /*preverify_ok*/, X509_STORE_CTX* ctx)
 		                              " a friend.";
 
 		Dbg1() << __PRETTY_FUNCTION__ << " " << errMsg << std::endl;
+
+
 
 		if(rsEvents && !isNotifyDenied(pgpId))
 		{
@@ -1942,6 +1950,17 @@ bool AuthSSLimpl::loadList(std::list<RsItem*>& load)
         return true;
 }
 
+
+
+const EVP_PKEY*RsX509Cert::getPubKey(const X509& x509)
+{
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+	return x509.cert_info->key->pkey;
+#else
+	return X509_get0_pubkey(&x509);
+#endif
+}
+
 void AuthSSLimpl::addNotifyDeny(const RsPgpId& pgpId, const std::string& name)
 {
 	RsStackMutex stack(sslMtx);
@@ -1959,20 +1978,19 @@ void AuthSSLimpl::removeNotifyDeny(const RsPgpId& pgpId)
 bool AuthSSLimpl::isNotifyDenied(const RsPgpId& pgpId)
 {
 	RsStackMutex stack(sslMtx);
-	return mDenyList.find(pgpId) != mDenyList.end();
+	if(mDenyList.find(pgpId) != mDenyList.end()) return true;
+
+    if(pgpId.isNull()) {
+        std::string s = pgpId.toStdString();
+        for(const auto& pair : mDenyList) {
+            if(pair.first.toStdString() == s) return true;
+        }
+    }
+	return false;
 }
 
 void AuthSSLimpl::getNotifyDenyList(std::map<RsPgpId, std::string>& ids)
 {
 	RsStackMutex stack(sslMtx);
 	ids = mDenyList;
-}
-
-const EVP_PKEY*RsX509Cert::getPubKey(const X509& x509)
-{
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-	return x509.cert_info->key->pkey;
-#else
-	return X509_get0_pubkey(&x509);
-#endif
 }

--- a/src/pqi/authssl.cc
+++ b/src/pqi/authssl.cc
@@ -1311,6 +1311,14 @@ int AuthSSLimpl::VerifyX509Callback(int /*preverify_ok*/, X509_STORE_CTX* ctx)
             return std::string();
     };
 
+    auto isStringDenied = [&](const std::string& s) -> bool {
+        RsStackMutex stack(sslMtx);
+        for(const auto& pair : mDenyList) {
+            if(pair.first.toStdString() == s) return true;
+        }
+        return false;
+    };
+
 	using Evt_t = RsAuthSslConnectionAutenticationEvent;
 	std::unique_ptr<Evt_t> ev = std::unique_ptr<Evt_t>(new Evt_t);
 
@@ -1338,14 +1346,14 @@ int AuthSSLimpl::VerifyX509Callback(int /*preverify_ok*/, X509_STORE_CTX* ctx)
 		if(!pgpFpr.isNull())
 			pgpId = PGPHandler::pgpIdFromFingerprint(pgpFpr);	// in the future, we drop PGP ids and keep the fingerprint all along
 	}
-
+    
 	if(sslId.isNull())
 	{
 		std::string errMsg = "x509Cert has invalid sslId!";
 
 		RsInfo() << __PRETTY_FUNCTION__ << " " << errMsg << std::endl;
 
-		if(rsEvents)
+		if(rsEvents && !isNotifyDenied(pgpId) && !isStringDenied(pgpId.toStdString()))
 		{
 			ev->mSslCn = sslCn;
 			ev->mSslId = sslId;
@@ -1367,7 +1375,7 @@ int AuthSSLimpl::VerifyX509Callback(int /*preverify_ok*/, X509_STORE_CTX* ctx)
 
 		RsInfo() << __PRETTY_FUNCTION__ << " " << errMsg << std::endl;
 
-		if(rsEvents)
+		if(rsEvents && !isNotifyDenied(pgpId) && !isStringDenied(pgpId.toStdString()))
 		{
 			ev->mSslId = sslId;
 			ev->mSslCn = sslCn;

--- a/src/pqi/authssl.cc
+++ b/src/pqi/authssl.cc
@@ -1425,7 +1425,7 @@ int AuthSSLimpl::VerifyX509Callback(int /*preverify_ok*/, X509_STORE_CTX* ctx)
 
 		RsInfo() << __PRETTY_FUNCTION__ << " " << errMsg << std::endl;
 
-		if(rsEvents)
+		if(rsEvents && !isNotifyDenied(pgpId))
 		{
 			ev->mSslId = sslId;
 			ev->mSslCn = sslCn;
@@ -1466,7 +1466,7 @@ int AuthSSLimpl::VerifyX509Callback(int /*preverify_ok*/, X509_STORE_CTX* ctx)
 
 		Dbg1() << __PRETTY_FUNCTION__ << " " << errMsg << std::endl;
 
-		if(rsEvents)
+		if(rsEvents && !isNotifyDenied(pgpId))
 		{
 			ev->mSslId = sslId;
 			ev->mSslCn = sslCn;
@@ -1873,6 +1873,18 @@ bool AuthSSLimpl::saveList(bool& cleanup, std::list<RsItem*>& lst)
         }
         lst.push_back(vitem);
 
+        /* Save Deny List */
+        if (!mDenyList.empty()) {
+            RsConfigKeyValueSet* denyItem = new RsConfigKeyValueSet;
+            for (const auto& pair : mDenyList) {
+                RsTlvKeyValue kv;
+                kv.key = pair.first.toStdString();
+                kv.value = "DENY:" + pair.second;
+                denyItem->tlvkvs.pairs.push_back(kv);
+            }
+            lst.push_back(denyItem);
+        }
+
         return true ;
 }
 
@@ -1902,6 +1914,11 @@ bool AuthSSLimpl::loadList(std::list<RsItem*>& load)
                                         continue;
                                 }
 
+                                if (kit->value.compare(0, 5, "DENY:") == 0) {
+                                    mDenyList[RsPgpId(kit->key)] = kit->value.substr(5);
+                                    continue;
+                                }
+
                                 X509 *peer = loadX509FromPEM(kit->value);
                                 /* authenticate it */
                                 uint32_t diagnos ;
@@ -1915,6 +1932,32 @@ bool AuthSSLimpl::loadList(std::list<RsItem*>& load)
         }
         load.clear() ;
         return true;
+}
+
+void AuthSSLimpl::addNotifyDeny(const RsPgpId& pgpId, const std::string& name)
+{
+	RsStackMutex stack(sslMtx);
+	mDenyList[pgpId] = name;
+	IndicateConfigChanged();
+}
+
+void AuthSSLimpl::removeNotifyDeny(const RsPgpId& pgpId)
+{
+	RsStackMutex stack(sslMtx);
+	mDenyList.erase(pgpId);
+	IndicateConfigChanged();
+}
+
+bool AuthSSLimpl::isNotifyDenied(const RsPgpId& pgpId)
+{
+	RsStackMutex stack(sslMtx);
+	return mDenyList.find(pgpId) != mDenyList.end();
+}
+
+void AuthSSLimpl::getNotifyDenyList(std::map<RsPgpId, std::string>& ids)
+{
+	RsStackMutex stack(sslMtx);
+	ids = mDenyList;
 }
 
 const EVP_PKEY*RsX509Cert::getPubKey(const X509& x509)

--- a/src/pqi/authssl.h
+++ b/src/pqi/authssl.h
@@ -112,6 +112,11 @@ public:
 
 	virtual X509* SignX509ReqWithGPG(X509_REQ* req, long days) = 0;
 
+	virtual void addNotifyDeny(const RsPgpId& pgpId, const std::string& name) = 0;
+	virtual void removeNotifyDeny(const RsPgpId& pgpId) = 0;
+	virtual bool isNotifyDenied(const RsPgpId& pgpId) = 0;
+	virtual void getNotifyDenyList(std::map<RsPgpId, std::string>& ids) = 0;
+
 	/**
 	 * @brief Verify PGP signature correcteness on given X509 certificate
 	 * Beware this doesn't check if the PGP signer is friend or not, just if the
@@ -207,6 +212,11 @@ public:
 	bool decrypt(void *&out, int &outlen, const void *in, int inlen) override;
 
 	virtual X509* SignX509ReqWithGPG(X509_REQ *req, long days) override;
+	
+	void addNotifyDeny(const RsPgpId& pgpId, const std::string& name) override;
+	void removeNotifyDeny(const RsPgpId& pgpId) override;
+	bool isNotifyDenied(const RsPgpId& pgpId) override;
+	void getNotifyDenyList(std::map<RsPgpId, std::string>& ids) override;
 
 	/// @see AuthSSL
 	bool AuthX509WithGPG(X509 *x509, bool verbose, uint32_t& auth_diagnostic) override;
@@ -265,4 +275,6 @@ private:
 	RsPgpId _last_gpgid_to_connect;
 	std::string _last_sslcn_to_connect;
 	RsPeerId _last_sslid_to_connect;
+
+	std::map<RsPgpId, std::string> mDenyList;
 };

--- a/src/rsserver/rsinit.cc
+++ b/src/rsserver/rsinit.cc
@@ -1802,6 +1802,7 @@ int RsServer::StartupRetroShare()
 	mConfigMgr->addConfiguration("gxsnettunnel.cfg", mGxsNetTunnel);
 	mConfigMgr->addConfiguration("peers.cfg"       , mPeerMgr);
 	mConfigMgr->addConfiguration("general.cfg"     , mGeneralConfig);
+    mConfigMgr->addConfiguration("authssl.cfg"     , dynamic_cast<p3Config*>(&AuthSSL::instance()));
 	mConfigMgr->addConfiguration("msgs.cfg"        , msgSrv);
 	mConfigMgr->addConfiguration("chat.cfg"        , chatSrv);
 	mConfigMgr->addConfiguration("p3History.cfg"   , mHistoryMgr);


### PR DESCRIPTION
implement persistent Ignore/Deny list with Names and PGP ID

works with retroshare-gui pr/3164

AuthSSL: Implement persistent Ignore/Deny list with Names
Enabled storing and retrieving ignored users (PGP ID and Name) in AuthSSL configuration.
Added API methods to add, remove, and check denied users.

