### PR TITLE
Add rsChats/getAvatar and rsChats/getOwnAvatar to the JSON API

### DIFF
--- a/src/chat/p3chatservice.cc
+++ b/src/chat/p3chatservice.cc
@@ -1501,6 +1501,27 @@ std::string p3ChatService::getCustomStateString(const RsPeerId& peer_id)
 	return std::string() ;
 }
 
+void p3ChatService::locked_requestAvatar(const RsPeerId& peer_id)
+{
+	/* Create placeholder to store request time */
+	std::map<RsPeerId,AvatarInfo *>::const_iterator it = _avatars.find(peer_id) ;
+
+	if(it == _avatars.end())
+	{
+		_avatars[peer_id] = new AvatarInfo();
+		it = _avatars.find(peer_id);
+	}
+
+	time_t now = time(NULL);
+	if (now - it->second->_last_request_time > 60) {
+#ifdef AVATAR_DEBUG
+		RsDbg() << "AVATAR p3ChatService::locked_requestAvatar: No avatar for peer " << peer_id << ". Requesting it (throttled).";
+#endif
+		it->second->_last_request_time = now;
+		sendAvatarRequest(peer_id);
+	}
+}
+
 void p3ChatService::getAvatarData(const RsPeerId& peer_id,unsigned char *& data,int& size)
 {
 	{
@@ -1525,22 +1546,58 @@ void p3ChatService::getAvatarData(const RsPeerId& peer_id,unsigned char *& data,
 #endif
 			return ;
 		} else {
-            /* Create placeholder to store request time */
-            if (it == _avatars.end()) {
-                 _avatars[peer_id] = new AvatarInfo();
-                 it = _avatars.find(peer_id);
-            }
+			data = NULL ;
+			size = 0 ;
 
-            time_t now = time(NULL);
-            if (now - it->second->_last_request_time > 60) {
-#ifdef AVATAR_DEBUG
-			    RsDbg() << "AVATAR p3ChatService::getAvatarData: No avatar for peer " << peer_id << ". Requesting it (throttled).";
-#endif
-                it->second->_last_request_time = now;
-                sendAvatarRequest(peer_id);
-            }
+			locked_requestAvatar(peer_id);
 		}
 	}
+}
+
+bool p3ChatService::getAvatar(const RsPeerId& pid, RsGxsImage& avatar)
+{
+	RS_STACK_MUTEX(mChatMtx);
+
+	avatar.clear();
+
+	std::map<RsPeerId,AvatarInfo *>::const_iterator it = _avatars.find(pid) ;
+
+	if(it != _avatars.end() && it->second->_image_size > 0)
+	{
+		unsigned char* data = NULL ;
+		uint32_t size = 0 ;
+		it->second->toUnsignedChar(data,size) ;
+
+		/* AvatarInfo::toUnsignedChar allocates with rs_malloc, and RsGxsImage
+		 * releases with free, so the buffer ownership can be handed over
+		 * without an extra copy. */
+		avatar.take(data,size);
+
+		it->second->_peer_is_new = false ;
+		return true;
+	}
+
+	/* Not available (yet): ask the peer for it, so that a later call may
+	 * succeed. */
+	locked_requestAvatar(pid);
+	return false;
+}
+
+bool p3ChatService::getOwnAvatar(RsGxsImage& avatar)
+{
+	RS_STACK_MUTEX(mChatMtx);
+
+	avatar.clear();
+
+	if(_own_avatar == NULL || _own_avatar->_image_size == 0)
+		return false;
+
+	unsigned char* data = NULL ;
+	uint32_t size = 0 ;
+	_own_avatar->toUnsignedChar(data,size) ;
+	avatar.take(data,size);
+
+	return true;
 }
 
 void p3ChatService::sendAvatarRequest(const RsPeerId& peer_id)

--- a/src/chat/p3chatservice.h
+++ b/src/chat/p3chatservice.h
@@ -174,6 +174,12 @@ public:
 		*/
     void getAvatarData(const RsPeerId& peer_id,unsigned char *& data,int& size) override;
 
+	/// @see RsChats
+	bool getAvatar(const RsPeerId& pid, RsGxsImage& avatar) override;
+
+	/// @see RsChats
+	bool getOwnAvatar(RsGxsImage& avatar) override;
+
 	/*!
 		 * Sets the avatar data and size for client's account
 		 * @param data is copied, so should be destroyed by the caller
@@ -275,6 +281,11 @@ private:
 
 	/// Sends a request for an avatar to the peer of given id
 	void sendAvatarRequest(const RsPeerId& peer_id) ;
+
+	/*! Create the avatar bookkeeping entry for the given peer if needed, then
+	 * ask the peer for its avatar, at most once per minute.
+	 * The caller MUST hold mChatMtx before calling this. */
+	void locked_requestAvatar(const RsPeerId& peer_id) ;
 
 	/// Send a request for custom status string
 	void sendCustomStateRequest(const RsPeerId& peer_id);

--- a/src/retroshare/rschats.h
+++ b/src/retroshare/rschats.h
@@ -25,6 +25,7 @@
 
 #include "retroshare/rstypes.h"
 #include "retroshare/rsevents.h"
+#include "retroshare/rsgxscommon.h"
 
 #define RS_CHAT_LOBBY_EVENT_PEER_LEFT   			0x01
 #define RS_CHAT_LOBBY_EVENT_PEER_STATUS 			0x02
@@ -463,6 +464,25 @@ public:
     // set own avatar data
     virtual void setOwnNodeAvatarData(const unsigned char *data,int size) = 0 ;
     virtual void getOwnNodeAvatarData(unsigned char *& data,int& size) = 0 ;
+
+    /**
+     * @brief getAvatar get the avatar of the given peer, in JPEG format
+     * @jsonapi{development}
+     * When the avatar of the peer is not known yet, this returns false and
+     * asks the peer to send it, so calling this again a bit later may succeed.
+     * @param[in] pid peer id
+     * @param[out] avatar peer avatar, left empty when not available
+     * @return true if an avatar was available, false otherwise
+     */
+    virtual bool getAvatar(const RsPeerId& pid, RsGxsImage& avatar) = 0;
+
+    /**
+     * @brief getOwnAvatar get the avatar of our own node, in JPEG format
+     * @jsonapi{development}
+     * @param[out] avatar own avatar, left empty when none has been set
+     * @return true if an avatar was set, false otherwise
+     */
+    virtual bool getOwnAvatar(RsGxsImage& avatar) = 0;
 
     /****************************************/
     /*            Chat lobbies              */


### PR DESCRIPTION
Add rsChats/getAvatar and rsChats/getOwnAvatar to the JSON API.

Supersedes #341 and #321, which encoded base64 by hand inside
p3ChatService.

Both methods return the avatar as an RsGxsImage, the container already
used to carry identity avatars over the JSON API. Its serial_process()
goes through RsTypeSerializer::RawMemoryWrapper, so the base64 wrapping
of the binary payload is produced by the serialization layer itself
rather than by the service, as requested in #1977. The resulting
representation is the one API clients already handle for identity
avatars:

    $ curl -u $API_TOKEN -d '{"pid":"<ssl id>"}' \
        $API_BASE_URL/rsChats/getAvatar
    {"avatar":{"mData":{"base64":"/9j/4AAQSkZJRgABAQ..."}},"retval":true}

When the avatar of a peer is not known yet, getAvatar() returns false
and asks the peer for it, so a later call may succeed.

The existing getAvatarData() is kept as is for its existing callers: it
hands out a raw malloc'ed buffer and an int size, which is neither
serializable nor usable from the JSON API, and the GUI still relies on
it. Its "create bookkeeping entry then ask the peer, at most once a
minute" part is factored out into locked_requestAvatar() and shared
with the new getAvatar(), and its out parameters are now explicitly
cleared when no avatar is available.