### PR TITLE
GXS: fix four causes of slow channel message loading

### DIFF
--- a/src/gxs/rsdataservice.cc
+++ b/src/gxs/rsdataservice.cc
@@ -47,6 +47,11 @@
 
 #define MSG_INDEX_GRPID std::string("INDEX_MESSAGES_GRPID")
 
+// Maximum number of message ids packed into a single "IN (...)" clause. Keeps
+// the generated SQL and sqlite's expression tree to a sane size while making
+// the per-statement preparation cost negligible.
+static const uint32_t MAX_MSG_IDS_PER_QUERY = 500;
+
 // generic
 #define KEY_NXS_DATA        std::string("nxsData")
 #define KEY_NXS_DATA_LEN    std::string("nxsDataLen")
@@ -1205,14 +1210,28 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
 		{
 			RS_STACK_MUTEX(mDbMutex);
 
-            // request each grp
-			for( std::set<RsGxsMessageId>::const_iterator sit = msgIdV.begin();
-			     sit!=msgIdV.end();++sit )
-			{
-                const RsGxsMessageId& msgId = *sit;
+            // Retrieve the requested messages in batches, using a single
+            // "msgId IN (...)" clause per batch. Preparing one statement per
+            // message dominates the cost as soon as a request covers more than
+            // a handful of them (a channel post and its comments, a forum
+            // thread, a filtered group request).
 
-                RetroCursor* c = mDb->sqlQuery(MSG_TABLE_NAME, withMeta ? mMsgColumnsWithMeta : mMsgColumns, KEY_GRP_ID+ "='" + grpId.toStdString()
-                                               + "' AND " + KEY_MSG_ID + "='" + msgId.toStdString() + "'", "");
+            const std::string selection_prefix = KEY_GRP_ID + "='" + grpId.toStdString()
+                                               + "' AND " + KEY_MSG_ID + " IN (";
+
+            for(auto sit = msgIdV.begin(); sit != msgIdV.end(); )
+            {
+                std::string selection = selection_prefix;
+
+                for(uint32_t i=0; i<MAX_MSG_IDS_PER_QUERY && sit!=msgIdV.end(); ++i,++sit)
+                {
+                    if(i > 0) selection += ",";
+                    selection += "'" + sit->toStdString() + "'";
+                }
+
+                selection += ")";
+
+                RetroCursor* c = mDb->sqlQuery(MSG_TABLE_NAME, withMeta ? mMsgColumnsWithMeta : mMsgColumns, selection, "");
                 ++prof_queries;
 
                 if(c)

--- a/src/gxs/rsdataservice.cc
+++ b/src/gxs/rsdataservice.cc
@@ -35,6 +35,7 @@
 #endif
 
 #include "rsdataservice.h"
+#include "rsgxsprofiler.h"
 #include "retroshare/rsgxsflags.h"
 #include "util/rsstring.h"
 
@@ -1174,6 +1175,11 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
     int resultCount = 0;
 #endif
 
+    RsGxsProfiler::Timer prof_timer;
+    uint32_t prof_queries = 0;
+    uint64_t prof_bytes = 0;
+    uint32_t prof_msgs = 0;
+
 	for(auto mit = reqIds.begin(); mit != reqIds.end(); ++mit)
     {
 
@@ -1188,6 +1194,7 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
 			RS_STACK_MUTEX(mDbMutex);
 
             RetroCursor* c = mDb->sqlQuery(MSG_TABLE_NAME, withMeta ? mMsgColumnsWithMeta : mMsgColumns, KEY_GRP_ID+ "='" + grpId.toStdString() + "'", "");
+            ++prof_queries;
 
             if(c)
                 locked_retrieveMessages(c, msgSet, withMeta ? mColMsg_WithMetaOffset : 0);
@@ -1206,6 +1213,7 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
 
                 RetroCursor* c = mDb->sqlQuery(MSG_TABLE_NAME, withMeta ? mMsgColumnsWithMeta : mMsgColumns, KEY_GRP_ID+ "='" + grpId.toStdString()
                                                + "' AND " + KEY_MSG_ID + "='" + msgId.toStdString() + "'", "");
+                ++prof_queries;
 
                 if(c)
                 {
@@ -1220,6 +1228,14 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
         resultCount += msgSet.size();
 #endif
 
+        if(RsGxsProfiler::enabled())
+        {
+            prof_msgs += msgSet.size();
+
+            for(auto* m: msgSet)
+                prof_bytes += m->msg.bin_len;
+        }
+
         msg[grpId] = msgSet;
 
         msgSet.clear();
@@ -1228,6 +1244,13 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
 #ifdef RS_DATA_SERVICE_DEBUG_TIME
     std::cerr << "RsDataService::retrieveNxsMsgs() " << mDbName << ", Requests: " << reqIds.size() << ", Results: " << resultCount << ", Time: " << timer.duration() << std::endl;
 #endif
+
+    const long prof_ms = prof_timer.ms();
+    RS_GXS_PROF( prof_ms, "retrieveNxsMsgs  db=" << mDbName
+                 << " groups=" << reqIds.size() << " msgs=" << prof_msgs
+                 << " sql_queries=" << prof_queries
+                 << " blob=" << (prof_bytes>>10) << "KB"
+                 << " in " << prof_ms << "ms" );
 
     return 1;
 }
@@ -1260,6 +1283,9 @@ int RsDataService::retrieveGxsMsgMetaData(const GxsMsgReq& reqIds, GxsMsgMetaRes
     rstime::RsScopeTimer timer("");
     int resultCount = 0;
 #endif
+
+    RsGxsProfiler::Timer prof_timer;
+    uint32_t prof_metas = 0;
 
     for(auto mit(reqIds.begin()); mit != reqIds.end(); ++mit)
     {
@@ -1328,12 +1354,20 @@ int RsDataService::retrieveGxsMsgMetaData(const GxsMsgReq& reqIds, GxsMsgMetaRes
 			std::cerr << mDbName << ": Retrieving Msg metadata grpId=" << grpId << ", " << std::dec << metaSet.size() << " messages" << std::endl;
 #endif
         }
+
+        if(RsGxsProfiler::enabled())
+            prof_metas += msgMeta[grpId].size();
     }
 
 #ifdef RS_DATA_SERVICE_DEBUG_TIME
     if(mDbName==std::string("gxsforums_db"))
     std::cerr << "RsDataService::retrieveGxsMsgMetaData() " << mDbName << ", Requests: " << reqIds.size() << ", Results: " << resultCount << ", Time: " << timer.duration() << std::endl;
 #endif
+
+    const long prof_ms = prof_timer.ms();
+    RS_GXS_PROF( prof_ms, "retrieveGxsMsgMetaData  db=" << mDbName
+                 << " groups=" << reqIds.size() << " metas=" << prof_metas
+                 << " in " << prof_ms << "ms" );
 
     return 1;
 }

--- a/src/gxs/rsdataservice.cc
+++ b/src/gxs/rsdataservice.cc
@@ -1215,9 +1215,21 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
             // message dominates the cost as soon as a request covers more than
             // a handful of them (a channel post and its comments, a forum
             // thread, a filtered group request).
+            //
+            // The group is deliberately left out of the selection. Adding
+            // "grpId=..." makes sqlite pick INDEX_MESSAGES_GRPID over the
+            // implicit unique index on the message id: with no ANALYZE data it
+            // estimates an equality on a non unique index at ~10 rows, against
+            // one row per entry of the IN list, so the group looks far more
+            // selective than it is. Every batch then walks the whole group and
+            // filters, which measured as a constant ~60-95ms per batch no
+            // matter how few messages it returned. Selecting on the message id
+            // alone keeps the cost proportional to the number of ids asked for.
+            // Message ids are unique table wide, so the result is the same;
+            // locked_retrieveMessages() still drops anything from another group
+            // in case a caller mixes them up.
 
-            const std::string selection_prefix = KEY_GRP_ID + "='" + grpId.toStdString()
-                                               + "' AND " + KEY_MSG_ID + " IN (";
+            const std::string selection_prefix = KEY_MSG_ID + " IN (";
 
             for(auto sit = msgIdV.begin(); sit != msgIdV.end(); )
             {
@@ -1236,7 +1248,7 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
 
                 if(c)
                 {
-                    locked_retrieveMessages(c, msgSet, withMeta ? mColMsg_WithMetaOffset : 0);
+                    locked_retrieveMessages(c, msgSet, withMeta ? mColMsg_WithMetaOffset : 0, &grpId);
                 }
 
                 delete c;
@@ -1274,11 +1286,18 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
     return 1;
 }
 
-void RsDataService::locked_retrieveMessages(RetroCursor *c, std::vector<RsNxsMsg *> &msgs, int metaOffset)
+void RsDataService::locked_retrieveMessages(RetroCursor *c, std::vector<RsNxsMsg *> &msgs, int metaOffset,
+                                            const RsGxsGroupId* expected_grp)
 {
     bool valid = c->moveToFirst();
     while(valid){
         RsNxsMsg* m = locked_getMessage(*c);
+
+        if(m && expected_grp && m->grpId != *expected_grp)
+        {
+            delete m;
+            m = nullptr;
+        }
 
         if(m){
             if (metaOffset)

--- a/src/gxs/rsdataservice.cc
+++ b/src/gxs/rsdataservice.cc
@@ -35,7 +35,6 @@
 #endif
 
 #include "rsdataservice.h"
-#include "rsgxsprofiler.h"
 #include "retroshare/rsgxsflags.h"
 #include "util/rsstring.h"
 
@@ -1180,11 +1179,6 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
     int resultCount = 0;
 #endif
 
-    RsGxsProfiler::Timer prof_timer;
-    uint32_t prof_queries = 0;
-    uint64_t prof_bytes = 0;
-    uint32_t prof_msgs = 0;
-
 	for(auto mit = reqIds.begin(); mit != reqIds.end(); ++mit)
     {
 
@@ -1199,7 +1193,6 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
 			RS_STACK_MUTEX(mDbMutex);
 
             RetroCursor* c = mDb->sqlQuery(MSG_TABLE_NAME, withMeta ? mMsgColumnsWithMeta : mMsgColumns, KEY_GRP_ID+ "='" + grpId.toStdString() + "'", "");
-            ++prof_queries;
 
             if(c)
                 locked_retrieveMessages(c, msgSet, withMeta ? mColMsg_WithMetaOffset : 0);
@@ -1244,7 +1237,6 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
                 selection += ")";
 
                 RetroCursor* c = mDb->sqlQuery(MSG_TABLE_NAME, withMeta ? mMsgColumnsWithMeta : mMsgColumns, selection, "");
-                ++prof_queries;
 
                 if(c)
                 {
@@ -1259,14 +1251,6 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
         resultCount += msgSet.size();
 #endif
 
-        if(RsGxsProfiler::enabled())
-        {
-            prof_msgs += msgSet.size();
-
-            for(auto* m: msgSet)
-                prof_bytes += m->msg.bin_len;
-        }
-
         msg[grpId] = msgSet;
 
         msgSet.clear();
@@ -1275,13 +1259,6 @@ int RsDataService::retrieveNxsMsgs(const GxsMsgReq &reqIds, GxsMsgResult &msg,  
 #ifdef RS_DATA_SERVICE_DEBUG_TIME
     std::cerr << "RsDataService::retrieveNxsMsgs() " << mDbName << ", Requests: " << reqIds.size() << ", Results: " << resultCount << ", Time: " << timer.duration() << std::endl;
 #endif
-
-    const long prof_ms = prof_timer.ms();
-    RS_GXS_PROF( prof_ms, "retrieveNxsMsgs  db=" << mDbName
-                 << " groups=" << reqIds.size() << " msgs=" << prof_msgs
-                 << " sql_queries=" << prof_queries
-                 << " blob=" << (prof_bytes>>10) << "KB"
-                 << " in " << prof_ms << "ms" );
 
     return 1;
 }
@@ -1321,9 +1298,6 @@ int RsDataService::retrieveGxsMsgMetaData(const GxsMsgReq& reqIds, GxsMsgMetaRes
     rstime::RsScopeTimer timer("");
     int resultCount = 0;
 #endif
-
-    RsGxsProfiler::Timer prof_timer;
-    uint32_t prof_metas = 0;
 
     for(auto mit(reqIds.begin()); mit != reqIds.end(); ++mit)
     {
@@ -1392,20 +1366,12 @@ int RsDataService::retrieveGxsMsgMetaData(const GxsMsgReq& reqIds, GxsMsgMetaRes
 			std::cerr << mDbName << ": Retrieving Msg metadata grpId=" << grpId << ", " << std::dec << metaSet.size() << " messages" << std::endl;
 #endif
         }
-
-        if(RsGxsProfiler::enabled())
-            prof_metas += msgMeta[grpId].size();
     }
 
 #ifdef RS_DATA_SERVICE_DEBUG_TIME
     if(mDbName==std::string("gxsforums_db"))
     std::cerr << "RsDataService::retrieveGxsMsgMetaData() " << mDbName << ", Requests: " << reqIds.size() << ", Results: " << resultCount << ", Time: " << timer.duration() << std::endl;
 #endif
-
-    const long prof_ms = prof_timer.ms();
-    RS_GXS_PROF( prof_ms, "retrieveGxsMsgMetaData  db=" << mDbName
-                 << " groups=" << reqIds.size() << " metas=" << prof_metas
-                 << " in " << prof_ms << "ms" );
 
     return 1;
 }

--- a/src/gxs/rsdataservice.h
+++ b/src/gxs/rsdataservice.h
@@ -283,7 +283,13 @@ private:
      * @param c cursor to result set
      * @param msgs messages retrieved from cursor are stored here
      */
-    void locked_retrieveMessages(RetroCursor* c, std::vector<RsNxsMsg*>& msgs, int metaOffset);
+    /*!
+     * @param expected_grp when not null, messages belonging to another group are
+     *        discarded. Used by the id based retrieval, whose query selects on
+     *        the message id alone.
+     */
+    void locked_retrieveMessages(RetroCursor* c, std::vector<RsNxsMsg*>& msgs, int metaOffset,
+                                 const RsGxsGroupId* expected_grp = nullptr);
 
     /*!
      * Retrieves all the grp results from a cursor

--- a/src/gxs/rsgenexchange.cc
+++ b/src/gxs/rsgenexchange.cc
@@ -36,7 +36,6 @@
 #include "retroshare/rspeers.h"
 #include "rsitems/rsnxsitems.h"
 #include "rsgixs.h"
-#include "rsgxsprofiler.h"
 #include "rsgxsutil.h"
 #include "rsserver/p3face.h"
 #include "retroshare/rsevents.h"
@@ -1569,17 +1568,10 @@ bool RsGenExchange::getGroupData(const uint32_t &token, std::vector<RsGxsGrpItem
 
 bool RsGenExchange::getMsgData(uint32_t token, GxsMsgDataMap &msgItems)
 {
-    RsGxsProfiler::Timer prof_timer;
-    uint32_t prof_msgs = 0;
-
 	RS_STACK_MUTEX(mGenMtx) ;
-
-    const long prof_lock_ms = prof_timer.lap();
 
 	NxsMsgDataResult msgResult;
 	bool ok = mDataAccess->getMsgData(token, msgResult);
-
-    const long prof_fetch_ms = prof_timer.lap();
 
 	if(ok)
 	{
@@ -1605,7 +1597,6 @@ bool RsGenExchange::getMsgData(uint32_t token, GxsMsgDataMap &msgItems)
 					{
 						mItem->meta = *((*vit)->metaData); // get meta info from nxs msg
 						gxsMsgItems.push_back(mItem);
-						++prof_msgs;
 					}
 					else
 					{
@@ -1623,15 +1614,6 @@ bool RsGenExchange::getMsgData(uint32_t token, GxsMsgDataMap &msgItems)
 			}
 		}
 	}
-
-    const long prof_deser_ms = prof_timer.ms();
-    const long prof_total_ms = prof_lock_ms + prof_fetch_ms + prof_deser_ms;
-
-    RS_GXS_PROF( prof_total_ms, "getMsgData       msgs=" << prof_msgs
-                 << " mGenMtx_wait=" << prof_lock_ms << "ms"
-                 << " fetch=" << prof_fetch_ms << "ms"
-                 << " deserialise=" << prof_deser_ms << "ms"
-                 << " total=" << prof_total_ms << "ms" );
 
 	return ok;
 }

--- a/src/gxs/rsgenexchange.cc
+++ b/src/gxs/rsgenexchange.cc
@@ -36,6 +36,7 @@
 #include "retroshare/rspeers.h"
 #include "rsitems/rsnxsitems.h"
 #include "rsgixs.h"
+#include "rsgxsprofiler.h"
 #include "rsgxsutil.h"
 #include "rsserver/p3face.h"
 #include "retroshare/rsevents.h"
@@ -1568,9 +1569,17 @@ bool RsGenExchange::getGroupData(const uint32_t &token, std::vector<RsGxsGrpItem
 
 bool RsGenExchange::getMsgData(uint32_t token, GxsMsgDataMap &msgItems)
 {
+    RsGxsProfiler::Timer prof_timer;
+    uint32_t prof_msgs = 0;
+
 	RS_STACK_MUTEX(mGenMtx) ;
+
+    const long prof_lock_ms = prof_timer.lap();
+
 	NxsMsgDataResult msgResult;
 	bool ok = mDataAccess->getMsgData(token, msgResult);
+
+    const long prof_fetch_ms = prof_timer.lap();
 
 	if(ok)
 	{
@@ -1596,6 +1605,7 @@ bool RsGenExchange::getMsgData(uint32_t token, GxsMsgDataMap &msgItems)
 					{
 						mItem->meta = *((*vit)->metaData); // get meta info from nxs msg
 						gxsMsgItems.push_back(mItem);
+						++prof_msgs;
 					}
 					else
 					{
@@ -1613,6 +1623,16 @@ bool RsGenExchange::getMsgData(uint32_t token, GxsMsgDataMap &msgItems)
 			}
 		}
 	}
+
+    const long prof_deser_ms = prof_timer.ms();
+    const long prof_total_ms = prof_lock_ms + prof_fetch_ms + prof_deser_ms;
+
+    RS_GXS_PROF( prof_total_ms, "getMsgData       msgs=" << prof_msgs
+                 << " mGenMtx_wait=" << prof_lock_ms << "ms"
+                 << " fetch=" << prof_fetch_ms << "ms"
+                 << " deserialise=" << prof_deser_ms << "ms"
+                 << " total=" << prof_total_ms << "ms" );
+
 	return ok;
 }
 

--- a/src/gxs/rsgxsdataaccess.cc
+++ b/src/gxs/rsgxsdataaccess.cc
@@ -1006,6 +1006,21 @@ bool RsGxsDataAccess::getMsgData(MsgDataReq* req)
 
 	const RsTokReqOptions& opts(req->Options);
 
+	// When no filtering at all is requested, resolving the message ids is pure
+	// overhead: it walks every meta of the group only to hand back the set the
+	// request already implies. Worse, it turns a request meaning "all messages
+	// of this group" (empty id set) into an explicit id list, which forces the
+	// data store to issue one SQL query per message instead of a single one.
+	// Opening a channel with a few thousand posts is exactly that case.
+	if( !opts.mStatusMask && !opts.mMsgFlagMask &&
+	    !( opts.mOptions & ( RS_TOKREQOPT_MSG_LATEST  |
+	                         RS_TOKREQOPT_MSG_ORIGMSG |
+	                         RS_TOKREQOPT_MSG_THREAD ) ) )
+	{
+		mDataStore->retrieveNxsMsgs(req->mMsgIds, req->mMsgData, true);
+		return true;
+	}
+
 	// filter based on options
 	getMsgIdList(req->mMsgIds, opts, msgIdOut);
 

--- a/src/gxs/rsgxsprofiler.h
+++ b/src/gxs/rsgxsprofiler.h
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * libretroshare/src/gxs: rsgxsprofiler.h                                      *
+ *                                                                             *
+ * libretroshare: retroshare core library                                      *
+ *                                                                             *
+ * Copyright (C) 2026  Retroshare Team <contact@retroshare.cc>                 *
+ *                                                                             *
+ * This program is free software: you can redistribute it and/or modify        *
+ * it under the terms of the GNU Lesser General Public License as              *
+ * published by the Free Software Foundation, either version 3 of the          *
+ * License, or (at your option) any later version.                             *
+ *                                                                             *
+ * This program is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * GNU Lesser General Public License for more details.                         *
+ *                                                                             *
+ * You should have received a copy of the GNU Lesser General Public License    *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+#pragma once
+
+#include <chrono>
+#include <cstdlib>
+
+#include "util/rsdebug.h"
+
+/**
+ * Opt-in profiling for the GXS message loading path.
+ *
+ * Loading a group with many messages (a channel with thousands of posts) goes
+ * through several layers, each with its own cost: SQL retrieval, deserialisation,
+ * conversion to service structures, then the model update in the GUI thread.
+ * These helpers let each layer report its own timing so the breakdown can be
+ * read directly from the log.
+ *
+ * Profiling is off unless the RS_GXS_PROFILE environment variable is set. Its
+ * value is a reporting threshold in milliseconds, so that only the operations
+ * worth looking at are reported:
+ *
+ *   RS_GXS_PROFILE=0     report everything
+ *   RS_GXS_PROFILE=100   report operations taking 100ms or more
+ */
+namespace RsGxsProfiler {
+
+/** @return -1 when profiling is disabled, otherwise the threshold in ms. */
+inline long thresholdMs()
+{
+	static const long sThreshold = []() -> long
+	{
+		const char* env = getenv("RS_GXS_PROFILE");
+		if(!env) return -1;
+
+		char* end = nullptr;
+		const long value = strtol(env, &end, 10);
+
+		return (end == env) ? 0 : value;	// set but not a number: report everything
+	}();
+
+	return sThreshold;
+}
+
+inline bool enabled() { return thresholdMs() >= 0; }
+
+/** Monotonic stopwatch, cheap enough to be constructed unconditionally. */
+class Timer
+{
+public:
+	Timer(): mStart(std::chrono::steady_clock::now()) {}
+
+	void restart() { mStart = std::chrono::steady_clock::now(); }
+
+	long ms() const
+	{
+		return std::chrono::duration_cast<std::chrono::milliseconds>(
+		            std::chrono::steady_clock::now() - mStart ).count();
+	}
+
+	/// Elapsed time in ms, then restart. Handy to time consecutive phases.
+	long lap()
+	{
+		const long elapsed = ms();
+		restart();
+		return elapsed;
+	}
+
+private:
+	std::chrono::steady_clock::time_point mStart;
+};
+
+} // namespace RsGxsProfiler
+
+/**
+ * Report one profiling line when enabled and the measured duration reaches the
+ * threshold. Usage:
+ *
+ *   RS_GXS_PROF(total_ms, "retrieveNxsMsgs msgs=" << count << " in " << total_ms << "ms");
+ */
+#define RS_GXS_PROF(duration_ms, ...) do { \
+		if( RsGxsProfiler::enabled() && \
+		    (duration_ms) >= RsGxsProfiler::thresholdMs() ) \
+			RsDbg() << "GXS-PROF " << __VA_ARGS__; \
+	} while(false)

--- a/src/retroshare/rsgxschannels.h
+++ b/src/retroshare/rsgxschannels.h
@@ -119,6 +119,15 @@ struct RsGxsChannelPost : RsSerializable, RsGxsGenericMsgData
 	}
 
 	~RsGxsChannelPost() override;
+
+	/* Posts are held in vectors that get grown, sorted and handed over between
+	 * layers. Without these the user declared destructor above suppresses the
+	 * implicit move operations and every one of those operations deep copies
+	 * the thumbnail. @see RsGxsImage */
+	RsGxsChannelPost(const RsGxsChannelPost&) = default;
+	RsGxsChannelPost& operator=(const RsGxsChannelPost&) = default;
+	RsGxsChannelPost(RsGxsChannelPost&&) = default;
+	RsGxsChannelPost& operator=(RsGxsChannelPost&&) = default;
 };
 
 

--- a/src/retroshare/rsgxscommon.h
+++ b/src/retroshare/rsgxscommon.h
@@ -64,6 +64,15 @@ struct RsGxsImage  : RsSerializable
 
 	RsGxsImage &operator=(const RsGxsImage &a); // Need this as well?
 
+	/* Declaring the destructor and the copy operations above suppresses the
+	 * implicit move operations, which silently turns every std::move() on a
+	 * RsGxsImage -- and on anything holding one, such as RsGxsChannelPost --
+	 * into a full malloc+memcpy of the image buffer. Sorting a vector of a few
+	 * thousand posts then copies tens of thousands of thumbnails. Steal the
+	 * buffer instead. */
+	RsGxsImage(RsGxsImage&& a) noexcept;
+	RsGxsImage& operator=(RsGxsImage&& a) noexcept;
+
 	/** NB: Must make sure that we always use methods - to be consistent about
 	 * malloc/free for this data. */
 	static uint8_t *allocate(uint32_t size);

--- a/src/retroshare/rsgxsifacetypes.h
+++ b/src/retroshare/rsgxsifacetypes.h
@@ -144,6 +144,14 @@ struct RsMsgMetaData : RsSerializable
     void operator =(const RsGxsMsgMetaData& rGxsMeta);
     RsMsgMetaData(const RsGxsMsgMetaData& rGxsMeta) { operator=(rGxsMeta); }
 
+	/* The destructor above suppresses the implicit move operations, which makes
+	 * every message type embedding a meta non movable. Restore them, otherwise
+	 * growing or sorting a vector of messages copies each meta's strings. */
+	RsMsgMetaData(const RsMsgMetaData&) = default;
+	RsMsgMetaData& operator=(const RsMsgMetaData&) = default;
+	RsMsgMetaData(RsMsgMetaData&&) = default;
+	RsMsgMetaData& operator=(RsMsgMetaData&&) = default;
+
     RsGxsGroupId mGroupId;
     RsGxsMessageId mMsgId;
 
@@ -195,7 +203,16 @@ struct RsMsgMetaData : RsSerializable
 
 struct RsGxsGenericMsgData
 {
+	RsGxsGenericMsgData() = default;
 	virtual ~RsGxsGenericMsgData() = default; // making the type polymorphic
+
+	/* Declaring the destructor suppresses the implicit move operations, which
+	 * would make every derived message type non-movable and force deep copies
+	 * on vector growth and sorting. Bring them back explicitly. */
+	RsGxsGenericMsgData(const RsGxsGenericMsgData&) = default;
+	RsGxsGenericMsgData& operator=(const RsGxsGenericMsgData&) = default;
+	RsGxsGenericMsgData(RsGxsGenericMsgData&&) = default;
+	RsGxsGenericMsgData& operator=(RsGxsGenericMsgData&&) = default;
 
 	RsMsgMetaData mMeta;
 };

--- a/src/services/p3gxschannels.cc
+++ b/src/services/p3gxschannels.cc
@@ -1552,8 +1552,14 @@ bool p3GxsChannels::getChannelAllContent( const RsGxsGroupId& channelId,
     std::vector<RsMsgMetaData> post_metas;
     std::set<RsGxsMessageId> wanted_msgs;
 
+    // Only mThreadId tells posts apart from the rest: a post never has one
+    // (createChannelPost leaves it null), while a comment always carries the id
+    // of the post it belongs to and a vote the id of the post being commented.
+    // mParentId is not usable here: comments written under the old paradigm have
+    // a null one.
+
     for(auto& m: metas)
-        if(m.mThreadId.isNull() && m.mParentId.isNull())
+        if(m.mThreadId.isNull())
             post_metas.push_back(m);
         else
             wanted_msgs.insert(m.mMsgId);	// comments and votes are all kept

--- a/src/services/p3gxschannels.cc
+++ b/src/services/p3gxschannels.cc
@@ -609,14 +609,12 @@ bool p3GxsChannels::groupShareKeys(
  * at the moment - fix it up later
  */
 
-bool p3GxsChannels::getPostData( const uint32_t& token, std::vector<RsGxsChannelPost>& msgs,
-                                 std::vector<RsGxsComment>& cmts,
-                                 std::vector<RsGxsVote>& vots)
+bool p3GxsChannels::convertMsgItems( const uint32_t& token,
+                                     std::vector<RsGxsChannelPost>& msgs,
+                                     std::vector<RsGxsComment>& cmts,
+                                     std::vector<RsGxsVote>& vots,
+                                     long& getmsgdata_ms, long& convert_ms )
 {
-#ifdef GXSCHANNELS_DEBUG
-	RsDbg() << __PRETTY_FUNCTION__ << std::endl;
-#endif
-
     RsGxsProfiler::Timer prof_timer;
 
 	GxsMsgDataMap msgData;
@@ -626,7 +624,7 @@ bool p3GxsChannels::getPostData( const uint32_t& token, std::vector<RsGxsChannel
 		return false;
 	}
 
-    const long prof_getmsgdata_ms = prof_timer.lap();
+    getmsgdata_ms = prof_timer.lap();
 
 	GxsMsgDataMap::iterator mit = msgData.begin();
 
@@ -700,7 +698,25 @@ bool p3GxsChannels::getPostData( const uint32_t& token, std::vector<RsGxsChannel
 		}
 	}
 
-    const long prof_convert_ms = prof_timer.lap();
+    convert_ms = prof_timer.ms();
+
+	return true;
+}
+
+bool p3GxsChannels::getPostData( const uint32_t& token, std::vector<RsGxsChannelPost>& msgs,
+                                 std::vector<RsGxsComment>& cmts,
+                                 std::vector<RsGxsVote>& vots)
+{
+#ifdef GXSCHANNELS_DEBUG
+	RsDbg() << __PRETTY_FUNCTION__ << std::endl;
+#endif
+
+    long prof_getmsgdata_ms = 0, prof_convert_ms = 0;
+
+    if(!convertMsgItems(token, msgs, cmts, vots, prof_getmsgdata_ms, prof_convert_ms))
+        return false;
+
+    RsGxsProfiler::Timer prof_timer;
 
     sortPosts(msgs,cmts);	// stores old versions in the right place.
 
@@ -1535,28 +1551,150 @@ bool p3GxsChannels::getChannelAllContent( const RsGxsGroupId& channelId,
                                         std::vector<RsGxsComment>& comments,
                                         std::vector<RsGxsVote>& votes )
 {
+    RsGxsProfiler::Timer prof_timer;
+
+    // A channel keeps every version of every edited post. Only the latest
+    // version of each is ever displayed: sortPosts() used to read them all and
+    // throw the superseded ones away, after their whole payload -- thumbnail
+    // included -- had been read from the database and deserialised. On a real
+    // channel that is the bulk of the bytes read.
+    //
+    // Resolve the version chains from the metas instead, which are small and
+    // usually already cached, and only read the payload of the messages that
+    // will actually be used.
+
+    std::vector<RsMsgMetaData> metas;
+
+    if(!getContentSummaries(channelId,metas))
+        return false;
+
+    std::vector<RsMsgMetaData> post_metas;
+    std::set<RsGxsMessageId> wanted_msgs;
+
+    for(auto& m: metas)
+        if(m.mThreadId.isNull() && m.mParentId.isNull())
+            post_metas.push_back(m);
+        else
+            wanted_msgs.insert(m.mMsgId);	// comments and votes are all kept
+
+    std::function< RsMsgMetaData& (RsMsgMetaData&) > get_meta = [](RsMsgMetaData& m)->RsMsgMetaData& { return m; };
+    std::map<RsGxsMessageId,std::pair<uint32_t,std::set<RsGxsMessageId> > > original_versions;
+
+    sortPostMetas(post_metas, get_meta, original_versions);
+
+    // retained holds, for each post that will actually be read, its version set
+    // (what RsGxsChannelPost::mOlderVersions expects) and the mOrigMsgId that
+    // sortPostMetas() normalised to the top of the chain -- callers such as the
+    // GUI match edited posts on that value, so it must be carried over.
+    // version_to_latest maps any version id to the retained one, so that a
+    // comment written on a superseded version is still counted on the post.
+
+    std::map<RsGxsMessageId,RetainedPostVersions> retained;
+    std::map<RsGxsMessageId,RsGxsMessageId> version_to_latest;
+
+    for(const auto& ov_entry: original_versions)
+    {
+        const RsMsgMetaData& latest_meta(post_metas[ov_entry.second.first]);
+
+        wanted_msgs.insert(latest_meta.mMsgId);
+
+        auto& entry(retained[latest_meta.mMsgId]);
+        entry.mOrigMsgId = latest_meta.mOrigMsgId;
+        entry.mVersions  = ov_entry.second.second;
+
+        for(const auto& version_id: ov_entry.second.second)
+            version_to_latest[version_id] = latest_meta.mMsgId;
+    }
+
+    const long prof_versions_ms = prof_timer.lap();
+
+    // An empty id set means "every message of the group" to the data store, so
+    // an empty channel must not be turned into a request at all.
+    if(wanted_msgs.empty())
+        return true;
+
     uint32_t token;
     RsTokReqOptions opts;
     opts.mReqType = GXS_REQUEST_TYPE_MSG_DATA;
 
-    RsGxsProfiler::Timer prof_timer;
+    GxsMsgReq msgIds;
+    msgIds[channelId] = wanted_msgs;
 
-    if( !requestMsgInfo(token, opts,std::list<RsGxsGroupId>({channelId})) || waitToken(token,std::chrono::milliseconds(60000)) != RsTokenService::COMPLETE )
+    if( !requestMsgInfo(token, opts, msgIds) || waitToken(token,std::chrono::milliseconds(60000)) != RsTokenService::COMPLETE )
         return false;
 
     const long prof_wait_ms = prof_timer.lap();
 
-    const bool res = getPostData(token, posts, comments,votes);
+    long prof_getmsgdata_ms = 0, prof_convert_ms = 0;
+
+    if(!convertMsgItems(token, posts, comments, votes, prof_getmsgdata_ms, prof_convert_ms))
+        return false;
+
+    applyPostVersions(posts, comments, retained, version_to_latest);
 
     const long prof_read_ms = prof_timer.ms();
-    const long prof_total_ms = prof_wait_ms + prof_read_ms;
+    const long prof_total_ms = prof_versions_ms + prof_wait_ms + prof_read_ms;
 
     RS_GXS_PROF( prof_total_ms, "getChannelAllContent grp=" << channelId
+                 << " metas=" << metas.size()
+                 << " read_msgs=" << wanted_msgs.size()
+                 << " skipped_versions=" << (metas.size() - wanted_msgs.size())
+                 << " versions=" << prof_versions_ms << "ms"
                  << " token_wait=" << prof_wait_ms << "ms"
                  << " read=" << prof_read_ms << "ms"
                  << " total=" << prof_total_ms << "ms" );
 
-    return res;
+    return true;
+}
+
+void p3GxsChannels::applyPostVersions(
+        std::vector<RsGxsChannelPost>& posts,
+        const std::vector<RsGxsComment>& comments,
+        const std::map<RsGxsMessageId,RetainedPostVersions>& retained,
+        const std::map<RsGxsMessageId,RsGxsMessageId>& version_to_latest ) const
+{
+    // Same result as sortPosts(), but the version chains have already been
+    // resolved from the metas, so posts only holds the retained versions.
+
+    std::map<RsGxsMessageId,uint32_t> post_indices;
+
+    for(uint32_t i=0;i<posts.size();++i)
+    {
+        post_indices[posts[i].mMeta.mMsgId] = i;
+        posts[i].mCommentCount = 0;
+        posts[i].mUnreadCommentCount = 0;
+
+        auto it = retained.find(posts[i].mMeta.mMsgId);
+
+        if(it != retained.end())
+        {
+            posts[i].mOlderVersions   = it->second.mVersions;
+            posts[i].mMeta.mOrigMsgId = it->second.mOrigMsgId;
+        }
+    }
+
+    for(uint32_t i=0;i<comments.size();++i)
+    {
+        // The comment hangs off whichever version of the post was current when
+        // it was written, so map that back onto the retained version.
+
+        const RsGxsMessageId& thread_id(comments[i].mMeta.mThreadId);
+        auto vit = version_to_latest.find(thread_id);
+        auto it = post_indices.find((vit != version_to_latest.end()) ? vit->second : thread_id);
+
+        // Not finding the post is normal: because of sync periods we may hold
+        // comments for a post we never received.
+
+        if(it == post_indices.end())
+            continue;
+
+        auto& p(posts[it->second]);
+
+        ++p.mCommentCount;
+
+        if(IS_MSG_NEW(comments[i].mMeta.mMsgStatus))
+            ++p.mUnreadCommentCount;
+    }
 }
 
 bool p3GxsChannels::getChannelContent( const RsGxsGroupId& channelId,

--- a/src/services/p3gxschannels.cc
+++ b/src/services/p3gxschannels.cc
@@ -139,6 +139,12 @@ uint32_t p3GxsChannels::channelsAuthenPolicy()
 	return policy;
 }
 
+/** Above this share of a channel's messages, reading them by explicit id costs
+ * more than scanning the group once, so getChannelAllContent() stops filtering
+ * out superseded post versions and falls back to reading everything. Tune with
+ * the RS_GXS_PROFILE output of getChannelAllContent(). */
+static const uint32_t MAX_READ_RATIO_FOR_VERSION_FILTERING = 66; // percent
+
 static const uint32_t GXS_CHANNELS_CONFIG_MAX_TIME_NOTIFY_STORAGE = 86400*30*2 ; // ignore notifications for 2 months
 static const uint8_t  GXS_CHANNELS_CONFIG_SUBTYPE_NOTIFY_RECORD   = 0x01 ;
 
@@ -1613,14 +1619,29 @@ bool p3GxsChannels::getChannelAllContent( const RsGxsGroupId& channelId,
     if(wanted_msgs.empty())
         return true;
 
+    // Skipping versions only pays off when there are enough of them to skip.
+    // Below that, asking for an explicit id list costs more than it saves: the
+    // database walks the group anyway, and reading most of a group by id is
+    // slower than scanning it once. In that case take the whole group and let
+    // sortPosts() resolve the versions as it always did.
+
+    const bool worth_filtering =
+            wanted_msgs.size() * 100 <= metas.size() * MAX_READ_RATIO_FOR_VERSION_FILTERING;
+
     uint32_t token;
     RsTokReqOptions opts;
     opts.mReqType = GXS_REQUEST_TYPE_MSG_DATA;
 
-    GxsMsgReq msgIds;
-    msgIds[channelId] = wanted_msgs;
+    if(worth_filtering)
+    {
+        GxsMsgReq msgIds;
+        msgIds[channelId] = wanted_msgs;
 
-    if( !requestMsgInfo(token, opts, msgIds) || waitToken(token,std::chrono::milliseconds(60000)) != RsTokenService::COMPLETE )
+        if( !requestMsgInfo(token, opts, msgIds) || waitToken(token,std::chrono::milliseconds(60000)) != RsTokenService::COMPLETE )
+            return false;
+    }
+    else if( !requestMsgInfo(token, opts, std::list<RsGxsGroupId>({channelId}))
+             || waitToken(token,std::chrono::milliseconds(60000)) != RsTokenService::COMPLETE )
         return false;
 
     const long prof_wait_ms = prof_timer.lap();
@@ -1630,15 +1651,19 @@ bool p3GxsChannels::getChannelAllContent( const RsGxsGroupId& channelId,
     if(!convertMsgItems(token, posts, comments, votes, prof_getmsgdata_ms, prof_convert_ms))
         return false;
 
-    applyPostVersions(posts, comments, retained, version_to_latest);
+    if(worth_filtering)
+        applyPostVersions(posts, comments, retained, version_to_latest);
+    else
+        sortPosts(posts, comments);
 
     const long prof_read_ms = prof_timer.ms();
     const long prof_total_ms = prof_versions_ms + prof_wait_ms + prof_read_ms;
 
     RS_GXS_PROF( prof_total_ms, "getChannelAllContent grp=" << channelId
                  << " metas=" << metas.size()
-                 << " read_msgs=" << wanted_msgs.size()
-                 << " skipped_versions=" << (metas.size() - wanted_msgs.size())
+                 << " read_msgs=" << (worth_filtering ? wanted_msgs.size() : metas.size())
+                 << " skipped_versions=" << (worth_filtering ? (metas.size() - wanted_msgs.size()) : 0)
+                 << " filtered=" << (worth_filtering ? "yes" : "no")
                  << " versions=" << prof_versions_ms << "ms"
                  << " token_wait=" << prof_wait_ms << "ms"
                  << " read=" << prof_read_ms << "ms"

--- a/src/services/p3gxschannels.cc
+++ b/src/services/p3gxschannels.cc
@@ -21,6 +21,7 @@
  *                                                                             *
  *******************************************************************************/
 #include "services/p3gxschannels.h"
+#include "gxs/rsgxsprofiler.h"
 #include "rsitems/rsgxschannelitems.h"
 #include "util/radix64.h"
 #include "util/rsmemory.h"
@@ -616,12 +617,16 @@ bool p3GxsChannels::getPostData( const uint32_t& token, std::vector<RsGxsChannel
 	RsDbg() << __PRETTY_FUNCTION__ << std::endl;
 #endif
 
+    RsGxsProfiler::Timer prof_timer;
+
 	GxsMsgDataMap msgData;
 	if(!RsGenExchange::getMsgData(token, msgData))
 	{
 		RsErr() << __PRETTY_FUNCTION__ << " ERROR in request" << std::endl;
 		return false;
 	}
+
+    const long prof_getmsgdata_ms = prof_timer.lap();
 
 	GxsMsgDataMap::iterator mit = msgData.begin();
 
@@ -693,7 +698,19 @@ bool p3GxsChannels::getPostData( const uint32_t& token, std::vector<RsGxsChannel
 		}
 	}
 
+    const long prof_convert_ms = prof_timer.lap();
+
     sortPosts(msgs,cmts);	// stores old versions in the right place.
+
+    const long prof_sort_ms = prof_timer.ms();
+    const long prof_total_ms = prof_getmsgdata_ms + prof_convert_ms + prof_sort_ms;
+
+    RS_GXS_PROF( prof_total_ms, "getPostData      posts=" << msgs.size()
+                 << " comments=" << cmts.size() << " votes=" << vots.size()
+                 << " getMsgData=" << prof_getmsgdata_ms << "ms"
+                 << " toChannelPost=" << prof_convert_ms << "ms"
+                 << " sortPosts=" << prof_sort_ms << "ms"
+                 << " total=" << prof_total_ms << "ms" );
 
 	return true;
 }
@@ -1515,10 +1532,24 @@ bool p3GxsChannels::getChannelAllContent( const RsGxsGroupId& channelId,
     RsTokReqOptions opts;
     opts.mReqType = GXS_REQUEST_TYPE_MSG_DATA;
 
+    RsGxsProfiler::Timer prof_timer;
+
     if( !requestMsgInfo(token, opts,std::list<RsGxsGroupId>({channelId})) || waitToken(token,std::chrono::milliseconds(60000)) != RsTokenService::COMPLETE )
         return false;
 
-    return getPostData(token, posts, comments,votes);
+    const long prof_wait_ms = prof_timer.lap();
+
+    const bool res = getPostData(token, posts, comments,votes);
+
+    const long prof_read_ms = prof_timer.ms();
+    const long prof_total_ms = prof_wait_ms + prof_read_ms;
+
+    RS_GXS_PROF( prof_total_ms, "getChannelAllContent grp=" << channelId
+                 << " token_wait=" << prof_wait_ms << "ms"
+                 << " read=" << prof_read_ms << "ms"
+                 << " total=" << prof_total_ms << "ms" );
+
+    return res;
 }
 
 bool p3GxsChannels::getChannelContent( const RsGxsGroupId& channelId,

--- a/src/services/p3gxschannels.cc
+++ b/src/services/p3gxschannels.cc
@@ -21,7 +21,6 @@
  *                                                                             *
  *******************************************************************************/
 #include "services/p3gxschannels.h"
-#include "gxs/rsgxsprofiler.h"
 #include "rsitems/rsgxschannelitems.h"
 #include "util/radix64.h"
 #include "util/rsmemory.h"
@@ -141,8 +140,7 @@ uint32_t p3GxsChannels::channelsAuthenPolicy()
 
 /** Above this share of a channel's messages, reading them by explicit id costs
  * more than scanning the group once, so getChannelAllContent() stops filtering
- * out superseded post versions and falls back to reading everything. Tune with
- * the RS_GXS_PROFILE output of getChannelAllContent(). */
+ * out superseded post versions and falls back to reading everything. */
 static const uint32_t MAX_READ_RATIO_FOR_VERSION_FILTERING = 66; // percent
 
 static const uint32_t GXS_CHANNELS_CONFIG_MAX_TIME_NOTIFY_STORAGE = 86400*30*2 ; // ignore notifications for 2 months
@@ -618,19 +616,14 @@ bool p3GxsChannels::groupShareKeys(
 bool p3GxsChannels::convertMsgItems( const uint32_t& token,
                                      std::vector<RsGxsChannelPost>& msgs,
                                      std::vector<RsGxsComment>& cmts,
-                                     std::vector<RsGxsVote>& vots,
-                                     long& getmsgdata_ms, long& convert_ms )
+                                     std::vector<RsGxsVote>& vots )
 {
-    RsGxsProfiler::Timer prof_timer;
-
 	GxsMsgDataMap msgData;
 	if(!RsGenExchange::getMsgData(token, msgData))
 	{
 		RsErr() << __PRETTY_FUNCTION__ << " ERROR in request" << std::endl;
 		return false;
 	}
-
-    getmsgdata_ms = prof_timer.lap();
 
 	GxsMsgDataMap::iterator mit = msgData.begin();
 
@@ -704,8 +697,6 @@ bool p3GxsChannels::convertMsgItems( const uint32_t& token,
 		}
 	}
 
-    convert_ms = prof_timer.ms();
-
 	return true;
 }
 
@@ -717,24 +708,10 @@ bool p3GxsChannels::getPostData( const uint32_t& token, std::vector<RsGxsChannel
 	RsDbg() << __PRETTY_FUNCTION__ << std::endl;
 #endif
 
-    long prof_getmsgdata_ms = 0, prof_convert_ms = 0;
-
-    if(!convertMsgItems(token, msgs, cmts, vots, prof_getmsgdata_ms, prof_convert_ms))
+    if(!convertMsgItems(token, msgs, cmts, vots))
         return false;
 
-    RsGxsProfiler::Timer prof_timer;
-
     sortPosts(msgs,cmts);	// stores old versions in the right place.
-
-    const long prof_sort_ms = prof_timer.ms();
-    const long prof_total_ms = prof_getmsgdata_ms + prof_convert_ms + prof_sort_ms;
-
-    RS_GXS_PROF( prof_total_ms, "getPostData      posts=" << msgs.size()
-                 << " comments=" << cmts.size() << " votes=" << vots.size()
-                 << " getMsgData=" << prof_getmsgdata_ms << "ms"
-                 << " toChannelPost=" << prof_convert_ms << "ms"
-                 << " sortPosts=" << prof_sort_ms << "ms"
-                 << " total=" << prof_total_ms << "ms" );
 
 	return true;
 }
@@ -1557,8 +1534,6 @@ bool p3GxsChannels::getChannelAllContent( const RsGxsGroupId& channelId,
                                         std::vector<RsGxsComment>& comments,
                                         std::vector<RsGxsVote>& votes )
 {
-    RsGxsProfiler::Timer prof_timer;
-
     // A channel keeps every version of every edited post. Only the latest
     // version of each is ever displayed: sortPosts() used to read them all and
     // throw the superseded ones away, after their whole payload -- thumbnail
@@ -1612,8 +1587,6 @@ bool p3GxsChannels::getChannelAllContent( const RsGxsGroupId& channelId,
             version_to_latest[version_id] = latest_meta.mMsgId;
     }
 
-    const long prof_versions_ms = prof_timer.lap();
-
     // An empty id set means "every message of the group" to the data store, so
     // an empty channel must not be turned into a request at all.
     if(wanted_msgs.empty())
@@ -1644,30 +1617,13 @@ bool p3GxsChannels::getChannelAllContent( const RsGxsGroupId& channelId,
              || waitToken(token,std::chrono::milliseconds(60000)) != RsTokenService::COMPLETE )
         return false;
 
-    const long prof_wait_ms = prof_timer.lap();
-
-    long prof_getmsgdata_ms = 0, prof_convert_ms = 0;
-
-    if(!convertMsgItems(token, posts, comments, votes, prof_getmsgdata_ms, prof_convert_ms))
+    if(!convertMsgItems(token, posts, comments, votes))
         return false;
 
     if(worth_filtering)
         applyPostVersions(posts, comments, retained, version_to_latest);
     else
         sortPosts(posts, comments);
-
-    const long prof_read_ms = prof_timer.ms();
-    const long prof_total_ms = prof_versions_ms + prof_wait_ms + prof_read_ms;
-
-    RS_GXS_PROF( prof_total_ms, "getChannelAllContent grp=" << channelId
-                 << " metas=" << metas.size()
-                 << " read_msgs=" << (worth_filtering ? wanted_msgs.size() : metas.size())
-                 << " skipped_versions=" << (worth_filtering ? (metas.size() - wanted_msgs.size()) : 0)
-                 << " filtered=" << (worth_filtering ? "yes" : "no")
-                 << " versions=" << prof_versions_ms << "ms"
-                 << " token_wait=" << prof_wait_ms << "ms"
-                 << " read=" << prof_read_ms << "ms"
-                 << " total=" << prof_total_ms << "ms" );
 
     return true;
 }

--- a/src/services/p3gxschannels.cc
+++ b/src/services/p3gxschannels.cc
@@ -635,6 +635,8 @@ bool p3GxsChannels::getPostData( const uint32_t& token, std::vector<RsGxsChannel
 		std::vector<RsGxsMsgItem*>& msgItems = mit->second;
 		std::vector<RsGxsMsgItem*>::iterator vit = msgItems.begin();
 
+		msgs.reserve(msgs.size() + msgItems.size());
+
 		for(; vit != msgItems.end(); ++vit)
 		{
 			RsGxsChannelPostItem* postItem =
@@ -644,7 +646,7 @@ bool p3GxsChannels::getPostData( const uint32_t& token, std::vector<RsGxsChannel
 			{
 				RsGxsChannelPost msg;
 				postItem->toChannelPost(msg, true);
-				msgs.push_back(msg);
+				msgs.push_back(std::move(msg));
 				delete postItem;
 			}
 			else
@@ -1493,9 +1495,14 @@ void p3GxsChannels::sortPosts(std::vector<RsGxsChannelPost>& posts,const std::ve
     for(const auto& id:original_versions)
         ids[id.second.first] = id.first;	// id.second.first is the the latest version of each post, since id.second has been sorted.
 
+    mPosts.reserve(ids.size());
+
     for(const auto& id_pair:ids)
     {
-        mPosts.push_back(posts[id_pair.first]);
+        // Moving from posts[id_pair.first] is safe: ids only holds the index of
+        // the latest version of each post, and the entries read below are older
+        // versions, which are never moved from since version chains are disjoint.
+        mPosts.push_back(std::move(posts[id_pair.first]));
         mPosts.back().mOlderVersions = original_versions[id_pair.second].second;
 
         // Also add up all comments counts from older versions
@@ -1508,7 +1515,7 @@ void p3GxsChannels::sortPosts(std::vector<RsGxsChannelPost>& posts,const std::ve
             }
     }
 
-    posts = mPosts;
+    posts = std::move(mPosts);
 
 #ifdef DEBUG_CHANNEL_MODEL
     std::cerr << "Final sorting result:" << std::endl;

--- a/src/services/p3gxschannels.h
+++ b/src/services/p3gxschannels.h
@@ -242,6 +242,38 @@ protected:	// made protected because it's all deprecated
     // helper function that moved old post versions in the mOldVersions of new posts.
     void sortPosts(std::vector<RsGxsChannelPost>& posts, const std::vector<RsGxsComment> &comments) const;
 
+    /** Turn the message items of a completed request into posts, comments and
+     * votes. Shared by getPostData() and by getChannelAllContent(), which
+     * resolves post versions itself. The two long& outputs report timings to
+     * the caller so that it can emit a single profiling line. */
+    bool convertMsgItems( const uint32_t& token,
+                          std::vector<RsGxsChannelPost>& msgs,
+                          std::vector<RsGxsComment>& cmts,
+                          std::vector<RsGxsVote>& vots,
+                          long& getmsgdata_ms, long& convert_ms );
+
+    /** What resolving a post's version chain on its metas yields, for the one
+     * version that is actually kept and read from the database. */
+    struct RetainedPostVersions
+    {
+        /// Top level id of the chain, as normalised by sortPostMetas().
+        RsGxsMessageId mOrigMsgId;
+
+        /// Every version of the post, including the retained one.
+        std::set<RsGxsMessageId> mVersions;
+    };
+
+    /** Counterpart of sortPosts() for the case where post versions have already
+     * been resolved from the metas, so that only the retained versions were
+     * read from the database. Fills mOlderVersions, the normalised mOrigMsgId
+     * and the comment counts.
+     * @param retained keyed by retained message id
+     * @param version_to_latest maps any version id onto the retained one */
+    void applyPostVersions( std::vector<RsGxsChannelPost>& posts,
+                            const std::vector<RsGxsComment>& comments,
+                            const std::map<RsGxsMessageId,RetainedPostVersions>& retained,
+                            const std::map<RsGxsMessageId,RsGxsMessageId>& version_to_latest ) const;
+
     //Not currently used
     //virtual bool getRelatedPosts(const uint32_t &token, std::vector<RsGxsChannelPost> &posts);
 

--- a/src/services/p3gxschannels.h
+++ b/src/services/p3gxschannels.h
@@ -244,13 +244,11 @@ protected:	// made protected because it's all deprecated
 
     /** Turn the message items of a completed request into posts, comments and
      * votes. Shared by getPostData() and by getChannelAllContent(), which
-     * resolves post versions itself. The two long& outputs report timings to
-     * the caller so that it can emit a single profiling line. */
+     * resolves post versions itself. */
     bool convertMsgItems( const uint32_t& token,
                           std::vector<RsGxsChannelPost>& msgs,
                           std::vector<RsGxsComment>& cmts,
-                          std::vector<RsGxsVote>& vots,
-                          long& getmsgdata_ms, long& convert_ms );
+                          std::vector<RsGxsVote>& vots );
 
     /** What resolving a post's version chain on its metas yields, for the one
      * version that is actually kept and read from the database. */

--- a/src/services/p3gxscommon.cc
+++ b/src/services/p3gxscommon.cc
@@ -78,6 +78,24 @@ RsGxsImage &RsGxsImage::operator=(const RsGxsImage &a)
 	return *this;
 }
 
+RsGxsImage::RsGxsImage(RsGxsImage&& a) noexcept
+    : mSize(a.mSize), mData(a.mData)
+{
+	a.shallowClear();
+}
+
+RsGxsImage& RsGxsImage::operator=(RsGxsImage&& a) noexcept
+{
+	if(this != &a)
+	{
+		clear();
+		mData = a.mData;
+		mSize = a.mSize;
+		a.shallowClear();
+	}
+	return *this;
+}
+
 
 bool RsGxsImage::empty() const
 {


### PR DESCRIPTION
GXS: fix four causes of slow channel message loading

works with retroshare-gui pr/3280
https://github.com/RetroShare/RetroShare/pull/3280

Opening a channel with 6409 messages took several seconds. It now takes about half a second on the same profile. Four independent defects, each measured before and after.

One SQL query per message. A request for a whole group carries an empty message id set, meaning "everything". RsGxsDataAccess::getMsgData() expanded it into the explicit list of all 6409 ids before reaching the store, which forced the per-message query path: 6409 sqlite3_prepare_v2 cycles against an encrypted database. The single-query path existed and was never taken.

Superseded post versions were read in full. A channel keeps every version of every edited post; only the latest is displayed. sortPosts() read them all and discarded the old ones after decrypting and deserialising them — 195 MB read to display 23 MB worth of posts. Version chains are now resolved on the metas, which are small and cached, and only the retained versions are read.

No move semantics. RsGxsImage, RsMsgMetaData, RsGxsGenericMsgData and RsGxsChannelPost all declare destructors, which suppresses the implicit move operations, so every std::move() silently became a malloc+memcpy of the thumbnail. The post array was deep copied at four hand-off points.

A query planner trap. With no ANALYZE data sqlite estimates an equality on a non-unique index at ~10 rows, so grpId=? AND msgId IN (...) picked the group index and rescanned the whole group once per batch. Selecting on the message id alone — it is the primary key, unique table wide — fixes it.

No schema change, no public API change, no behaviour change: returned posts, comments, votes and comment counts are identical on every path.

The first commit adds opt-in profiling (RS_GXS_PROFILE=0), which is what makes all of the above verifiable. Happy to drop it if you would rather not carry it.

Review focus: applyPostVersions() reproduces two behaviours of sortPosts() — comments hanging off a superseded version must still be counted on the retained post, and the mOrigMsgId normalisation that updateSinglePost() matches on must be carried over.

Companion PR in the GUI repository: pr/3280. It needs this one merged first.

