### PR TITLE
Fix build break from #345: add missing DirEntry::dir_cumulated_files

### DIFF
--- a/src/file_sharing/dir_hierarchy.cc
+++ b/src/file_sharing/dir_hierarchy.cc
@@ -674,15 +674,21 @@ uint64_t InternalFileHierarchyStorage::recursUpdateCumulatedSize(const Directory
     DirEntry& d(*static_cast<DirEntry*>(mNodes[dir_index])) ;
 
     uint64_t local_cumulative_size = 0;
+    uint32_t local_cumulative_files = 0;
 
     for(uint32_t i=0;i<d.subfiles.size();++i)
-        if(mNodes[d.subfiles[i]])		// normally not needed, but an extra-security
+        if(mNodes[d.subfiles[i]]) {		// normally not needed, but an extra-security
             local_cumulative_size += static_cast<FileEntry*>(mNodes[d.subfiles[i]])->file_size;
+            local_cumulative_files++;
+        }
 
-    for(uint32_t i=0;i<d.subdirs.size();++i)
+    for(uint32_t i=0;i<d.subdirs.size();++i) {
         local_cumulative_size += recursUpdateCumulatedSize(d.subdirs[i]);
+        local_cumulative_files += static_cast<DirEntry*>(mNodes[d.subdirs[i]])->dir_cumulated_files;
+    }
 
     d.dir_cumulated_size = local_cumulative_size;
+    d.dir_cumulated_files = local_cumulative_files;
     return local_cumulative_size;
 }
 // Do a complete recursive sweep over sub-directories and files, and update the lst modf TS. This could be also performed by a cleanup method.

--- a/src/file_sharing/dir_hierarchy.h
+++ b/src/file_sharing/dir_hierarchy.h
@@ -63,7 +63,7 @@ public:
     class DirEntry: public FileStorageNode
     {
     public:
-        explicit DirEntry(const std::string& name) : dir_name(name), dir_cumulated_size(0), dir_modtime(0),dir_most_recent_time(0),dir_update_time(0) {}
+        explicit DirEntry(const std::string& name) : dir_name(name), dir_cumulated_size(0), dir_cumulated_files(0), dir_modtime(0),dir_most_recent_time(0),dir_update_time(0) {}
         virtual ~DirEntry() {}
 
         virtual uint32_t type() const { return FileStorageNode::TYPE_DIR ; }
@@ -73,6 +73,7 @@ public:
         std::string dir_parent_path ;
         RsFileHash  dir_hash ;
         uint64_t    dir_cumulated_size;
+        uint32_t    dir_cumulated_files;
 
         std::vector<DirectoryStorage::EntryIndex> subdirs ;
         std::vector<DirectoryStorage::EntryIndex> subfiles ;

--- a/src/file_sharing/directory_storage.cc
+++ b/src/file_sharing/directory_storage.cc
@@ -258,6 +258,7 @@ bool DirectoryStorage::extractData(const EntryIndex& indx,DirDetails& d)
         d.type = DIR_TYPE_DIR;
         d.hash.clear() ;
         d.size   = dir_entry->dir_cumulated_size;//dir_entry->subdirs.size() + dir_entry->subfiles.size();
+        d.count  = dir_entry->dir_cumulated_files;
         d.max_mtime = dir_entry->dir_most_recent_time ;
         d.mtime     = dir_entry->dir_modtime ;
         d.name    = dir_entry->dir_name;

--- a/src/retroshare/rstypes.h
+++ b/src/retroshare/rstypes.h
@@ -280,7 +280,7 @@ struct DirStub : RsSerializable
 struct DirDetails : RsSerializable
 {
 	DirDetails() : parent(nullptr), prow(0), ref(nullptr),
-        type(DIR_TYPE_UNKNOWN), size(0), mtime(0), max_mtime(0) {}
+        type(DIR_TYPE_UNKNOWN), size(0), mtime(0), max_mtime(0), count(0) {}
 
 
 	/* G10h4ck do we still need to keep this as void* instead of uint64_t for
@@ -302,6 +302,7 @@ struct DirDetails : RsSerializable
 	uint32_t mtime;			// file/directory modification time, according to what the system reports
 	FileStorageFlags flags;
 	uint32_t max_mtime ;	// maximum modification time of the whole hierarchy below.
+	uint32_t count;			// cumulative number of files in the directory hierarchy.
 
     std::vector<DirStub> children;
     std::list<RsNodeGroupId> parent_groups;	// parent groups for the shared directory
@@ -331,6 +332,7 @@ struct DirDetails : RsSerializable
 		RS_SERIAL_PROCESS(mtime);
 		RS_SERIAL_PROCESS(flags);
 		RS_SERIAL_PROCESS(max_mtime);
+		RS_SERIAL_PROCESS(count);
 		RS_SERIAL_PROCESS(children);
 		RS_SERIAL_PROCESS(parent_groups);
 	}


### PR DESCRIPTION
#345 used `DirEntry::dir_cumulated_files` in the new `DirectoryStorage::getDirectoryCumulatedFileCount()`, but the commit introducing that member was on a separate local branch and was not included in the PR — so master no longer compiles (first caught by the Android GitLab CI, but it breaks every platform):

```
src/file_sharing/directory_storage.cc:147:21: error: no member named 'dir_cumulated_files' in 'InternalFileHierarchyStorage::DirEntry'
```

This adds the missing piece: `dir_cumulated_files` is maintained alongside `dir_cumulated_size` in `recursUpdateCumulatedSize()`, which already runs on hierarchy load and on `checkSave()` for both local and remote directories, so the count used by the #345 cleanup logic is always up to date. Also exposed as `DirDetails::count` (cumulative file count of the hierarchy below), which the GUI can use later to display file counts.

Sorry for the breakage — the PR was developed and tested on a tree that already carried this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)