### PR TITLE
fix(rsaccounts): locate the data directory relative to the executable on Linux

### DIFF
--- a/src/rsserver/rsaccounts.cc
+++ b/src/rsserver/rsaccounts.cc
@@ -794,6 +794,35 @@ static bool checkAccount(const std::string &accountdir, AccountDetails &account,
 	//#include <CFBundle.h>
 #endif
 
+#if defined(__linux__) && !defined(__ANDROID__)
+#include <limits.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+/* Data directory of a relocatable install, derived from the running executable:
+ * <exedir>/../share/retroshare. Empty when there is no such directory, so a
+ * regular system wide install keeps using the compile time RS_DATA_DIR. */
+static std::string relocatableDataDirectory()
+{
+	char exePath[PATH_MAX];
+	ssize_t pathLen = readlink("/proc/self/exe", exePath, sizeof(exePath)-1);
+	if(pathLen <= 0) return std::string();
+	exePath[pathLen] = '\0';
+
+	std::string candidate(exePath);
+	size_t lastSlash = candidate.rfind('/');
+	if(lastSlash == std::string::npos) return std::string();
+	candidate.replace(lastSlash, std::string::npos, "/../share/retroshare");
+
+	if(!RsDirUtil::checkDirectory(candidate)) return std::string();
+
+	char resolved[PATH_MAX];
+	if(realpath(candidate.c_str(), resolved)) candidate = resolved;
+
+	return candidate;
+}
+#endif // defined(__linux__) && !defined(__ANDROID__)
+
 /*static*/ std::string RsAccountsDetail::PathDataDirectory(bool check)
 {
 	std::string dataDirectory;
@@ -854,6 +883,22 @@ static bool checkAccount(const std::string &accountdir, AccountDetails &account,
 	// cppcheck-suppress ConfigurationNotChecked
 	dataDirectory = RS_DATA_DIR;
 	// For all other OS the data directory must be set in libretroshare.pro
+
+#if defined(__linux__) && !defined(__ANDROID__)
+	/* An AppImage or any other self contained tree is mounted at a location
+	 * unknown at compile time, so RS_DATA_DIR cannot point inside it: when data
+	 * is shipped next to the executable, that copy wins over the system one. */
+	{
+		const std::string relocated = relocatableDataDirectory();
+		if(!relocated.empty())
+		{
+			dataDirectory = relocated;
+			std::cerr << "getRetroshareDataDirectory() relocatable: "
+			          << dataDirectory << std::endl;
+		}
+	}
+#endif // defined(__linux__) && !defined(__ANDROID__)
+
 #else
 #	error "For your target OS automatic data dir discovery is not supported, cannot compile if RS_DATA_DIR variable not set."
 #endif


### PR DESCRIPTION
`RS_DATA_DIR` is baked in at compile time, so a relocatable tree (AppImage, portable directory, staged install) can never find its own data: the binary reads the host's system-wide path instead, or nothing at all.

On Linux (excluding Android) prefer `<exedir>/../share/retroshare` when that directory exists, and fall back to `RS_DATA_DIR` otherwise. System-wide installs and build trees are unaffected.

This covers every file served from the data directory; the web UI in particular, which `p3webui` resolves as `PathDataDirectory() + "/webui/"`.

Verified on Linux: a binary placed in a relocated tree resolves its own data directory, while the same binary in a build tree still reports `RS_DATA_DIR`. Full Qt5 build green.
