### PR TITLE
Refactor CMakeLists.txt files

### DIFF
--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -52,15 +52,43 @@ jobs:
         openssl@3 botan@2 sqlcipher miniupnpc json-c
         bzip2 zlib doxygen gnu-sed rapidjson
 
-    # The restbed patch step of CMakeLists.txt runs `sed -i -e ...`, which is
-    # GNU syntax: BSD sed reads the argument after -i as a backup suffix and
-    # fails with "sed: -e: No such file or directory". The super-project never
-    # hits it -- it has restbed as a submodule and takes the add_subdirectory
-    # branch instead of FetchContent -- so this only shows up in the standalone
-    # build. Put GNU sed first in PATH rather than patch the CMakeLists.
+    - name: Install BitDHT
+      run: |
+        git clone https://github.com/dbear496/RetroShare_BitDHT.git libbitdht \
+          --branch cmake-refactor
+        cd libbitdht
+        cmake -G Ninja -B build
+        cmake --build build -j$(nproc)
+
+    - name: Install restbed
+      run: |
+        git clone https://github.com/Corvusoft/restbed.git
+        cd restbed
+        git checkout --detach 6001a322809b5005b8bcccdf593fdda6f0173691
+        cmake -G Ninja -B build -DBUILD_TESTS=NO -DBUILD_SSL=NO \
+          -DBUILD_STATIC_LIBRARY=YES -DBUILD_SHARED_LIBRARY=NO \
+          -DBUILD_DEVEL_PACKAGE=YES \
+          --install-prefix=/usr/local -DCMAKE_INSTALL_LIBDIR=lib
+        cmake --build build -j$(nproc)
+        sudo cmake --install build
+
+    - name: Install rnp
+      run: |
+        git clone https://github.com/rnpgp/rnp.git --recurse-submodules
+        cd rnp
+        cmake -G Ninja -B build
+        cmake --build build -j$(nproc)
+        sudo cmake --install build
+
+    - name: Install udp-discovery-cpp
+      run: |
+        git clone https://github.com/truvorskameikin/udp-discovery-cpp.git
+        cd udp-discovery-cpp
+        cmake -G Ninja -B build
+        cmake --build build -j$(nproc)
+
     - name: CMake configure
       run: |
-        export PATH="$(brew --prefix gnu-sed)/libexec/gnubin:$PATH"
         HB="$(brew --prefix)"
         IFLAGS="-I$HB/include"; for d in "$HB"/opt/*/include; do IFLAGS="$IFLAGS -I$d"; done
         LFLAGS="-L$HB/lib";     for d in "$HB"/opt/*/lib;     do LFLAGS="$LFLAGS -L$d"; done

--- a/.github/workflows/ubuntu-cmake.yml
+++ b/.github/workflows/ubuntu-cmake.yml
@@ -53,8 +53,43 @@ jobs:
         sudo apt-get install -y
         build-essential g++ cmake ninja-build pkg-config git
         libssl-dev zlib1g-dev libbz2-dev libjson-c-dev libbotan-2-dev rapidjson-dev
-        libsqlcipher-dev libminiupnpc-dev
+        libsqlcipher-dev libminiupnpc-dev libasio-dev
         doxygen python3
+
+    - name: Install BitDHT
+      run: |
+        git clone https://github.com/dbear496/RetroShare_BitDHT.git libbitdht \
+          --branch cmake-refactor
+        cd libbitdht
+        cmake -G Ninja -B build
+        cmake --build build -j$(nproc)
+
+    - name: Install restbed
+      run: |
+        git clone https://github.com/Corvusoft/restbed.git
+        cd restbed
+        git checkout --detach 6001a322809b5005b8bcccdf593fdda6f0173691
+        cmake -G Ninja -B build -DBUILD_TESTS=NO -DBUILD_SSL=NO \
+          -DBUILD_STATIC_LIBRARY=YES -DBUILD_SHARED_LIBRARY=NO \
+          -DBUILD_DEVEL_PACKAGE=YES \
+          --install-prefix=/usr/local -DCMAKE_INSTALL_LIBDIR=lib
+        cmake --build build -j$(nproc)
+        sudo cmake --install build
+
+    - name: Install rnp
+      run: |
+        git clone https://github.com/rnpgp/rnp.git --recurse-submodules
+        cd rnp
+        cmake -G Ninja -B build
+        cmake --build build -j$(nproc)
+        sudo cmake --install build
+
+    - name: Install udp-discovery-cpp
+      run: |
+        git clone https://github.com/truvorskameikin/udp-discovery-cpp.git
+        cd udp-discovery-cpp
+        cmake -G Ninja -B build
+        cmake --build build -j$(nproc)
 
     - name: CMake configure
       run: >
@@ -65,6 +100,9 @@ jobs:
         -DRS_SQLCIPHER=ON -DRS_BITDHT=ON
         -DRS_BRODCAST_DISCOVERY=ON -DRS_MINIUPNPC=ON
         -DRS_FORUM_DEEP_INDEX=OFF
+        -DBITDHT_ROOT=${{github.workspace}}/libbitdht/build
+        -DRAPIDJSON_ROOT=${{github.workspace}}/rapidjson/build
+        -DUDP-DISCOVERY-CPP_ROOT=${{github.workspace}}/udp-discovery-cpp\;${{github.workspace}}/udp-discovery-cpp/build
 
     - name: CMake build
       run: cmake --build Build-cmake -j$(nproc)

--- a/.github/workflows/ubuntu-cmake.yml
+++ b/.github/workflows/ubuntu-cmake.yml
@@ -51,10 +51,9 @@ jobs:
       run: >
         sudo apt-get update &&
         sudo apt-get install -y
-        build-essential g++ cmake ninja-build pkg-config git
-        libssl-dev zlib1g-dev libbz2-dev libjson-c-dev libbotan-2-dev rapidjson-dev
-        libsqlcipher-dev libminiupnpc-dev libasio-dev
-        doxygen python3
+        build-essential g++ cmake ninja-build pkg-config git libssl-dev
+        zlib1g-dev libbz2-dev libjson-c-dev libbotan-2-dev rapidjson-dev
+        libsqlcipher-dev libminiupnpc-dev libasio-dev doxygen python3
 
     - name: Install BitDHT
       run: |

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -82,6 +82,42 @@ jobs:
             mingw-w64-ucrt-x86_64-bzip2
             mingw-w64-ucrt-x86_64-zlib
 
+      - name: Install BitDHT
+        run: |
+          git clone https://github.com/dbear496/RetroShare_BitDHT.git \
+            libbitdht --branch cmake-refactor
+          cd libbitdht
+          cmake -G Ninja -B build
+          cmake --build build -j$(nproc)
+
+      - name: Install restbed
+        run: |
+          git clone https://github.com/Corvusoft/restbed.git
+          cd restbed
+          git checkout --detach 6001a322809b5005b8bcccdf593fdda6f0173691
+          cmake -G Ninja -B build -DBUILD_TESTS=NO -DBUILD_SSL=NO \
+            -DBUILD_STATIC_LIBRARY=YES -DBUILD_SHARED_LIBRARY=NO \
+            -DBUILD_DEVEL_PACKAGE=YES \
+            --install-prefix="C:/Program Files/restbed" \
+            -DCMAKE_INSTALL_LIBDIR=lib
+          cmake --build build -j$(nproc)
+          cmake --install build
+
+      - name: Install rnp
+        run: |
+          git clone https://github.com/rnpgp/rnp.git --recurse-submodules
+          cd rnp
+          cmake -G Ninja -B build
+          cmake --build build -j$(nproc)
+          cmake --install build
+
+      - name: Install udp-discovery-cpp
+        run: |
+          git clone https://github.com/truvorskameikin/udp-discovery-cpp.git
+          cd udp-discovery-cpp
+          cmake -G Ninja -B build
+          cmake --build build -j$(nproc)
+
       - name: CMake configure
         run: |
           cmake -G Ninja -B Build-cmake -S . \
@@ -91,6 +127,9 @@ jobs:
             -DRS_SQLCIPHER=ON -DRS_BITDHT=ON \
             -DRS_BRODCAST_DISCOVERY=OFF -DRS_MINIUPNPC=ON \
             -DRS_FORUM_DEEP_INDEX=OFF \
+            -DBITDHT_ROOT=${{github.workspace}}/libbitdht/build \
+            -DRAPIDJSON_ROOT=${{github.workspace}}/rapidjson/build \
+            -DUDP-DISCOVERY-CPP_ROOT=${{github.workspace}}/udp-discovery-cpp\;${{github.workspace}}/udp-discovery-cpp/build \
             -DCMAKE_C_FLAGS="-include string.h -include stdint.h" \
             -DCMAKE_CXX_FLAGS="-include cstring -include cstdint -Wno-template-body"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-cmake_minimum_required(VERSION 4.4.0...4.4.1)
+cmake_minimum_required(VERSION 3.24...4.4.1)
 project(retroshare
 	VERSION 0.6.7
 	LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,7 +432,10 @@ if(RS_BITDHT)
 	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_BITDHT)
 	target_link_libraries(${PROJECT_NAME} PRIVATE bitdht::bitdht)
 
-	install(FILES "${BD_BOOT_FILE}" DESTINATION "${RS_DATA_DIR}")
+	install(FILES "${BD_BOOT_FILE}"
+		DESTINATION "${RS_DATA_DIR}"
+		COMPONENT libretroshare
+	)
 
 	if(RS_BITDHT_STUNNER)
 		target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_DHT_STUNNER)
@@ -472,7 +475,7 @@ endif()
 if(RS_MINIUPNPC)
 	find_package(MiniUPnPc REQUIRED)
 	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_LIBMINIUPNPC)
-	target_link_libraries(${PROJECT_NAME} PRIVATE MiniUPnPc::MiniUPnPc)
+	target_link_libraries(${PROJECT_NAME} PRIVATE miniupnpc::miniupnpc)
 endif(RS_MINIUPNPC)
 
 if(RS_LIBUPNP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,9 +229,13 @@ set(LIBRS_MINI_VERSION "${PROJECT_VERSION_PATCH}")
 if(DEFINED RS_EXTRA_VERSION AND NOT (RS_EXTRA_VERSION STREQUAL ""))
 	set(LIBRS_EXTRA_VERSION "${RS_EXTRA_VERSION}")
 else()
-	git_describe_working_tree(V_GIT_DESCRIBE --tags --long --always --dirty --match v*.*.*)
+	git_describe_working_tree(V_GIT_DESCRIBE
+		--tags --long --always --dirty --match v*.*.*
+	)
 	set(V_GIT_DESCRIBE_REGEXP "^v([0-9]+).([0-9]+).([0-9]+)(.*)$")
-	if(V_GIT_DESCRIBE AND V_GIT_DESCRIBE MATCHES "${V_GIT_DESCRIBE_REGEXP}")
+	if(NOT V_GIT_DESCRIBE)
+		set(LIBRS_EXTRA_VERSION "-unknown")
+	elseif(V_GIT_DESCRIBE MATCHES "${V_GIT_DESCRIBE_REGEXP}")
 		string(
 			REGEX REPLACE
 			"${V_GIT_DESCRIBE_REGEXP}" "\\1;\\2;\\3;\\4"
@@ -240,13 +244,17 @@ else()
 		list(GET V_GIT_DESCRIBE_LIST 1 LIBRS_MINOR_VERSION)
 		list(GET V_GIT_DESCRIBE_LIST 2 LIBRS_MINI_VERSION)
 		list(GET V_GIT_DESCRIBE_LIST 3 LIBRS_EXTRA_VERSION)
-	elseif(V_GIT_DESCRIBE)
-		set(LIBRS_EXTRA_VERSION "-${V_GIT_DESCRIBE}")
 	else()
-		set(LIBRS_EXTRA_VERSION "-unknown")
+		set(LIBRS_EXTRA_VERSION "-${V_GIT_DESCRIBE}")
 	endif()
 endif()
-message(STATUS "libRetroShare version ${LIBRS_MAJOR_VERSION}.${LIBRS_MINOR_VERSION}.${LIBRS_MINI_VERSION}${LIBRS_EXTRA_VERSION}")
+string(CONCAT LIBRS_FULL_VERSION
+	${LIBRS_MAJOR_VERSION}
+	.${LIBRS_MINOR_VERSION}
+	.${LIBRS_MINI_VERSION}
+	"${LIBRS_EXTRA_VERSION}"
+)
+message(STATUS "libretroshare version ${LIBRS_FULL_VERSION}")
 
 
 ################################################################################
@@ -290,6 +298,7 @@ target_link_libraries(${PROJECT_NAME}
 
 target_compile_definitions(${PROJECT_NAME}
 	PUBLIC
+	"LIBRS_FULL_VERSION=${LIBRS_FULL_VERSION}"
 	"LIBRS_MAJOR_VERSION=${LIBRS_MAJOR_VERSION}"
 	"LIBRS_MINOR_VERSION=${LIBRS_MINOR_VERSION}"
 	"LIBRS_MINI_VERSION=${LIBRS_MINI_VERSION}"
@@ -439,7 +448,6 @@ endif(RS_BITDHT)
 find_package(RapidJSON REQUIRED)
 target_link_libraries(${PROJECT_NAME} PUBLIC RapidJSON)
 get_target_property(tmp RapidJSON INTERFACE_INCLUDE_DIRECTORIES)
-message(STATUS "rapidjson interface: ${tmp}")
 
 ################################################################################
 ### SQLite3 / SQLCipher
@@ -578,17 +586,7 @@ install(
 	COMPONENT libretroshare
 	EXCLUDE_FROM_ALL
 	LIBRARY DESTINATION "${RS_LIB_INSTALL_DIR}"
-	PUBLIC_HEADER DESTINATION "${RS_INCLUDE_INSTALL_DIR}"
+	FILE_SET HEADERS DESTINATION "${RS_INCLUDE_INSTALL_DIR}"
 )
 
-## As of today libretroshare doesn't hide implementation details properly so it
-## is necessary to install private headers too
-foreach(P_HEADER ${RS_IMPLEMENTATION_HEADERS})
-	get_filename_component(P_DIR "${P_HEADER}" DIRECTORY)
-	install(
-		FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/${P_HEADER}"
-		DESTINATION "${RS_INCLUDE_INSTALL_DIR}/${P_DIR}"
-		COMPONENT libretroshare
-		EXCLUDE_FROM_ALL
-	)
-endforeach()
+## TODO: export targets and create config packages for install and build trees

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,6 @@ find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(BZip2 REQUIRED)
 find_package(ZLIB REQUIRED)
-find_package(Xapian)
 
 ################################################################################
 ### build configuration
@@ -263,33 +262,12 @@ else()
 	message(FATAL_ERROR "must specify either RS_LIBRETROSHARE_STATIC or RS_LIBRETROSHARE_SHARED")
 endif()
 
-if(BUILD_SHARED_LIBS)
-	## Ensure statically linked libraries such as openpgpsdk are compiled with
-	## PIC Which is needed for shared library
-	## Not sure if this is needed. In any case, it would need to be set before any
-	## library targets are created.
-	# set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-endif()
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(WIN32)
 	# Force Unicode mappings for Windows API (fixes MoveFileEx and similar errors)
 	add_definitions(-DUNICODE -D_UNICODE)
-
-	if(BUILD_SHARED_LIBS)
-		set_target_properties(${PROJECT_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
-		if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-			# We must use an explicit list of heavy 3rd-party archives instead of "ALL" for --exclude-libs.
-			# Using "ALL" also hides symbols from CMake's internal objects.a archive (created by WINDOWS_EXPORT_ALL_SYMBOLS),
-			# which prevents libretroshare from exporting its own core C++ symbols, causing massive linkage errors downstream.
-			target_link_options(${PROJECT_NAME} PRIVATE "-Wl,--export-all-symbols,--exclude-libs,libbitdht.a:librnp.a:libsexpp.a:libudp-discovery.a:librestbed.a:libsqlcipher.a:libbotan-2.a:libbotan-3.a:libz.a:libbz2.a")
-		endif()
-	endif()
-endif()
-
-if(RS_ANDROID)
-	if(BUILD_SHARED_LIBS)
-		target_link_options(${PROJECT_NAME} PRIVATE LINKER:--no-undefined)
-	endif()
 endif()
 
 ################################################################################
@@ -312,10 +290,10 @@ target_link_libraries(${PROJECT_NAME}
 
 target_compile_definitions(${PROJECT_NAME}
 	PUBLIC
-	LIBRS_MAJOR_VERSION="${LIBRS_MAJOR_VERSION}"
-	LIBRS_MINOR_VERSION="${LIBRS_MINOR_VERSION}"
-	LIBRS_MINI_VERSION="${LIBRS_MINI_VERSION}"
-	LIBRS_EXTRA_VERSION="${LIBRS_EXTRA_VERSION}"
+	"LIBRS_MAJOR_VERSION=${LIBRS_MAJOR_VERSION}"
+	"LIBRS_MINOR_VERSION=${LIBRS_MINOR_VERSION}"
+	"LIBRS_MINI_VERSION=${LIBRS_MINI_VERSION}"
+	"LIBRS_EXTRA_VERSION=${LIBRS_EXTRA_VERSION}"
 	PRIVATE
 	SQLITE_HAS_CODEC
 	RS_ENABLE_GXS
@@ -353,12 +331,9 @@ if(RS_GXSTHEWIRE)
 endif(RS_GXSTHEWIRE)
 
 if(RS_FORUM_DEEP_INDEX)
-	if(NOT Xapian_FOUND)
-		message(FATAL_ERROR "forum deep index requires Xapian")
-	endif()
+	find_package(Xapian REQUIRED)
 
 	target_link_libraries(${PROJECT_NAME} PRIVATE ${XAPIAN_LIBRARIES})
-
 	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_DEEP_FORUMS_INDEX)
 endif(RS_FORUM_DEEP_INDEX)
 
@@ -430,11 +405,11 @@ endif()
 if(RS_RNPLIB)
 	find_package(rnp REQUIRED)
 
-	target_link_libraries(${PROJECT_NAME} PRIVATE rnp::librnp)
+	target_link_libraries(${PROJECT_NAME} PUBLIC rnp::librnp)
 else()
 	find_package(openpgpsdk REQUIRED)
 
-	target_link_libraries(${PROJECT_NAME} PRIVATE openpgpsdk::openpgpsdk)
+	target_link_libraries(${PROJECT_NAME} PUBLIC openpgpsdk::openpgpsdk)
 
 	target_compile_definitions(${PROJECT_NAME} PUBLIC USE_OPENPGPSDK)
 endif(RS_RNPLIB)
@@ -522,7 +497,7 @@ endif(RS_CPPTRACE_STACKTRACE)
 ### Linux
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	target_compile_definitions(${PROJECT_NAME} PUBLIC
-		RS_DATA_DIR="${RS_DATA_DIR}"
+		"RS_DATA_DIR=\"${CMAKE_INSTALL_PREFIX}/${RS_DATA_DIR}\""
 	)
 endif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,7 +430,9 @@ if(RS_BITDHT)
 	find_package(bitdht REQUIRED)
 
 	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_BITDHT)
-	target_link_libraries(${PROJECT_NAME} PRIVATE bitdht)
+	target_link_libraries(${PROJECT_NAME} PRIVATE bitdht::bitdht)
+
+	install(FILES "${BD_BOOT_FILE}" DESTINATION "${RS_DATA_DIR}")
 
 	if(RS_BITDHT_STUNNER)
 		target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_DHT_STUNNER)
@@ -447,7 +449,6 @@ endif(RS_BITDHT)
 
 find_package(RapidJSON REQUIRED)
 target_link_libraries(${PROJECT_NAME} PUBLIC RapidJSON)
-get_target_property(tmp RapidJSON INTERFACE_INCLUDE_DIRECTORIES)
 
 ################################################################################
 ### SQLite3 / SQLCipher

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,21 @@
 # RetroShare decentralized communication platform
 #
 # Copyright (C) 2021-2026  Gioacchino Mazzurco <gio@retroshare.cc>
+# Copyright (C) 2026       David Bears <dbear4q@gmail.com>
 #
 # SPDX-License-Identifier: CC0-1.0
 
-cmake_minimum_required (VERSION 3.18.0)
-project(retroshare)
+cmake_minimum_required(VERSION 4.4.0...4.4.1)
+project(retroshare
+	VERSION 0.6.7
+	LANGUAGES CXX C
+)
+
+
+################################################################################
+### options
 
 include(CMakeDependentOption)
-include(GNUInstallDirs)
-
-set(FETCHCONTENT_QUIET OFF)
-include(FetchContent)
-
-if(WIN32)
-	# Force Unicode mappings for Windows API (fixes MoveFileEx and similar errors)
-	add_definitions(-DUNICODE -D_UNICODE)
-endif()
 
 option(
 	RS_SQLCIPHER
@@ -133,26 +132,23 @@ option(
 	"Build the experimental, off-by-default GXS 'The Wire' service"
 	OFF )
 
-option(
-	RS_LIBRETROSHARE_STANDALONE_INSTALL
-	"Install libretroshare as a stand-alone library"
-	OFF )
+include(GNUInstallDirs)
 
 set(
 	RS_DATA_DIR
-	"${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}"
+	"${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}"
 	CACHE PATH
 	"Path where to install RetroShare system wide data" )
 
 set(
 	RS_INCLUDE_INSTALL_DIR
-	"${CMAKE_INSTALL_FULL_INCLUDEDIR}/${PROJECT_NAME}"
+	"${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}"
 	CACHE PATH
 	"Path where to install libretroshare headers" )
 
 set(
 	RS_LIB_INSTALL_DIR
-	"${CMAKE_INSTALL_FULL_LIBDIR}"
+	"${CMAKE_INSTALL_LIBDIR}"
 	CACHE PATH
 	"Path where to install libretroshare compiled library" )
 
@@ -196,75 +192,90 @@ option(
 	OFF )
 
 set(
-	RS_MAJOR_VERSION
-	""
-	CACHE STRING
-	"Specify RetroShare major version" )
-
-set(
-	RS_MINOR_VERSION
-	""
-	CACHE STRING
-	"Specify RetroShare minor version" )
-
-set(
-	RS_MINI_VERSION
-	""
-	CACHE STRING
-	"Specify RetroShare mini version" )
-
-set(
 	RS_EXTRA_VERSION
 	""
 	CACHE STRING
 	"Specify an extra string to append to RetroShare version to make it more descriptive" )
 
 ################################################################################
+### dependencies
 
-find_package(Git REQUIRED)
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/mk/cmake")
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+set(FETCHCONTENT_QUIET OFF)
+include(FetchContent)
+
+find_package(Threads REQUIRED)
+find_package(OpenSSL REQUIRED)
+find_package(BZip2 REQUIRED)
+find_package(ZLIB REQUIRED)
+find_package(Xapian)
 
 ################################################################################
+### build configuration
 
 if(RS_DEVELOPMENT_BUILD)
 	set(CMAKE_VERBOSE_MAKEFILE ON)
 	set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif(RS_DEVELOPMENT_BUILD)
 
+
 ################################################################################
+### version
 
-include(src/CMakeLists.txt)
-list(TRANSFORM RS_SOURCES PREPEND src/)
-list(TRANSFORM RS_PUBLIC_HEADERS PREPEND src/)
+include(GetGitRevisionDescription)
+set(LIBRS_MAJOR_VERSION "${PROJECT_VERSION_MAJOR}")
+set(LIBRS_MINOR_VERSION "${PROJECT_VERSION_MINOR}")
+set(LIBRS_MINI_VERSION "${PROJECT_VERSION_PATCH}")
+if(DEFINED RS_EXTRA_VERSION AND NOT (RS_EXTRA_VERSION STREQUAL ""))
+	set(LIBRS_EXTRA_VERSION "${RS_EXTRA_VERSION}")
+else()
+	git_describe_working_tree(V_GIT_DESCRIBE --tags --long --always --dirty --match v*.*.*)
+	set(V_GIT_DESCRIBE_REGEXP "^v([0-9]+).([0-9]+).([0-9]+)(.*)$")
+	if(V_GIT_DESCRIBE AND V_GIT_DESCRIBE MATCHES "${V_GIT_DESCRIBE_REGEXP}")
+		string(
+			REGEX REPLACE
+			"${V_GIT_DESCRIBE_REGEXP}" "\\1;\\2;\\3;\\4"
+			V_GIT_DESCRIBE_LIST "${V_GIT_DESCRIBE}" )
+		list(GET V_GIT_DESCRIBE_LIST 0 LIBRS_MAJOR_VERSION)
+		list(GET V_GIT_DESCRIBE_LIST 1 LIBRS_MINOR_VERSION)
+		list(GET V_GIT_DESCRIBE_LIST 2 LIBRS_MINI_VERSION)
+		list(GET V_GIT_DESCRIBE_LIST 3 LIBRS_EXTRA_VERSION)
+	elseif(V_GIT_DESCRIBE)
+		set(LIBRS_EXTRA_VERSION "-${V_GIT_DESCRIBE}")
+	else()
+		set(LIBRS_EXTRA_VERSION "-unknown")
+	endif()
+endif()
+message(STATUS "libRetroShare version ${LIBRS_MAJOR_VERSION}.${LIBRS_MINOR_VERSION}.${LIBRS_MINI_VERSION}${LIBRS_EXTRA_VERSION}")
 
-if(RS_LIBRETROSHARE_STATIC)
-	add_library(${PROJECT_NAME} STATIC ${RS_SOURCES})
-endif(RS_LIBRETROSHARE_STATIC)
 
-if(RS_LIBRETROSHARE_SHARED)
-	add_library(${PROJECT_NAME} SHARED ${RS_SOURCES})
+################################################################################
+### general compilation options
 
+if(RS_LIBRETROSHARE_STATIC AND RS_LIBRETROSHARE_SHARED)
+	message(FATAL_ERROR "building both static and shared library is not supported")
+elseif(RS_LIBRETROSHARE_STATIC)
+	set(BUILD_SHARED_LIBS NO)
+elseif(RS_LIBRETROSHARE_SHARED)
+	set(BUILD_SHARED_LIBS YES)
+else()
+	message(FATAL_ERROR "must specify either RS_LIBRETROSHARE_STATIC or RS_LIBRETROSHARE_SHARED")
+endif()
+
+if(BUILD_SHARED_LIBS)
 	## Ensure statically linked libraries such as openpgpsdk are compiled with
 	## PIC Which is needed for shared library
-	set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+	## Not sure if this is needed. In any case, it would need to be set before any
+	## library targets are created.
+	# set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
 
-	## Make the linker fail at build time if libretroshare.so contains any
-	## undefined symbol, instead of silently producing a .so that crashes at
-	## runtime with
-	## java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol $symbol
-	## This is especially important on Android where every dependency (bzip2,
-	## OpenSSL, SQLite, librnp, ...) is statically linked: an undefined
-	## reference in libretroshare.so has no provider at runtime, unlike on
-	## Linux where those deps are shared system libraries resolved via
-	## DT_NEEDED.
-	## The same hardening would be valuable on other platforms too
-	## (-Wl,-z,defs on Linux, -Wl,-undefined,error on macOS) but there the
-	## shared-deps model makes the trade-off less clear, so it is
-	## Android-only for now.
-	if(RS_ANDROID)
-		target_link_options(${PROJECT_NAME} PRIVATE LINKER:--no-undefined)
-	endif()
+if(WIN32)
+	# Force Unicode mappings for Windows API (fixes MoveFileEx and similar errors)
+	add_definitions(-DUNICODE -D_UNICODE)
 
-	if(WIN32)
+	if(BUILD_SHARED_LIBS)
 		set_target_properties(${PROJECT_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 		if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 			# We must use an explicit list of heavy 3rd-party archives instead of "ALL" for --exclude-libs.
@@ -273,10 +284,249 @@ if(RS_LIBRETROSHARE_SHARED)
 			target_link_options(${PROJECT_NAME} PRIVATE "-Wl,--export-all-symbols,--exclude-libs,libbitdht.a:librnp.a:libsexpp.a:libudp-discovery.a:librestbed.a:libsqlcipher.a:libbotan-2.a:libbotan-3.a:libz.a:libbz2.a")
 		endif()
 	endif()
-endif(RS_LIBRETROSHARE_SHARED)
+endif()
+
+if(RS_ANDROID)
+	if(BUILD_SHARED_LIBS)
+		target_link_options(${PROJECT_NAME} PRIVATE LINKER:--no-undefined)
+	endif()
+endif()
+
+################################################################################
+### targets
+
+add_library(${PROJECT_NAME})
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
 
+target_link_libraries(${PROJECT_NAME}
+	## TODO: I have a suspicion some of these need to be public
+	PRIVATE
+	${CMAKE_DL_LIBS}
+	Threads::Threads
+	OpenSSL::SSL
+	OpenSSL::Crypto
+	BZip2::BZip2
+	ZLIB::ZLIB
+)
+
+target_compile_definitions(${PROJECT_NAME}
+	PUBLIC
+	LIBRS_MAJOR_VERSION="${LIBRS_MAJOR_VERSION}"
+	LIBRS_MINOR_VERSION="${LIBRS_MINOR_VERSION}"
+	LIBRS_MINI_VERSION="${LIBRS_MINI_VERSION}"
+	LIBRS_EXTRA_VERSION="${LIBRS_EXTRA_VERSION}"
+	PRIVATE
+	SQLITE_HAS_CODEC
+	RS_ENABLE_GXS
+	GXS_ENABLE_SYNC_MSGS
+	RS_USE_GXS_DISTANT_SYNC
+	RS_GXS_TRANS
+	V07_NON_BACKWARD_COMPATIBLE_CHANGE_001
+	V07_NON_BACKWARD_COMPATIBLE_CHANGE_002
+	V07_NON_BACKWARD_COMPATIBLE_CHANGE_003
+)
+
+if(RS_DEVELOPMENT_BUILD)
+	target_compile_options(${PROJECT_NAME} PRIVATE "-O0")
+endif(RS_DEVELOPMENT_BUILD)
+
+if(RS_SPLIT_DEBUG)
+	target_compile_options(${PROJECT_NAME} PRIVATE "-g")
+	target_compile_options(${PROJECT_NAME} PRIVATE "-gsplit-dwarf")
+endif(RS_SPLIT_DEBUG)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release" AND NOT RS_NO_LTO)
+	set_property(TARGET ${PROJECT_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION ON)
+endif()
+
+if(RS_USE_CALENDAR)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_CALENDAR)
+endif(RS_USE_CALENDAR)
+
+if(RS_GXSWIKIPOS)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_WIKI)
+endif(RS_GXSWIKIPOS)
+
+if(RS_GXSTHEWIRE)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_WIRE)
+endif(RS_GXSTHEWIRE)
+
+if(RS_FORUM_DEEP_INDEX)
+	if(NOT Xapian_FOUND)
+		message(FATAL_ERROR "forum deep index requires Xapian")
+	endif()
+
+	target_link_libraries(${PROJECT_NAME} PRIVATE ${XAPIAN_LIBRARIES})
+
+	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_DEEP_FORUMS_INDEX)
+endif(RS_FORUM_DEEP_INDEX)
+
+if(RS_GXS_SEND_ALL)
+	target_compile_definitions(
+		${PROJECT_NAME} PUBLIC RS_GXS_SEND_ALL )
+endif(RS_GXS_SEND_ALL)
+
+if(RS_V07_BREAKING_CHANGES)
+	target_compile_definitions(${PROJECT_NAME} PRIVATE
+		V07_NON_BACKWARD_COMPATIBLE_CHANGE_004
+		V07_NON_BACKWARD_COMPATIBLE_CHANGE_UNNAMED
+	)
+endif()
+
+if(NOT RS_DH_PRIME_INIT_CHECK)
+	target_compile_definitions(${PROJECT_NAME} PRIVATE
+		RS_DISABLE_DIFFIE_HELLMAN_INIT_CHECK
+	)
+endif(NOT RS_DH_PRIME_INIT_CHECK)
+
+if(NOT RS_WARN_DEPRECATED)
+	target_compile_definitions(${PROJECT_NAME} PRIVATE RS_NO_WARN_DEPRECATED)
+	target_compile_options(${PROJECT_NAME} PRIVATE
+		-Wno-deprecated
+		-Wno-deprecated-declarations
+	)
+endif(NOT RS_WARN_DEPRECATED)
+
+if(RS_WARN_LESS)
+	target_compile_definitions(${PROJECT_NAME} PRIVATE RS_NO_WARN_CPP)
+
+	target_compile_options(${PROJECT_NAME} PRIVATE
+		-Wno-cpp
+		-Wno-inconsistent-missing-override
+	)
+endif(RS_WARN_LESS)
+
+if(RS_WEBUI)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_WEBUI)
+endif(RS_WEBUI)
+
+if(RS_EXPORT_JNI_ONLOAD)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC
+		RS_LIBRETROSHARE_EXPORT_JNI_ONLOAD
+	)
+endif(RS_EXPORT_JNI_ONLOAD)
+
+
+################################################################################
+### libsam3
+
+if(RS_USE_I2P_SAM3)
+	find_package(libsam3 REQUIRED)
+	target_link_libraries(${PROJECT_NAME}
+		PRIVATE
+		libsam3::libsam3
+	)
+	target_compile_definitions(${PROJECT_NAME}
+		PRIVATE
+		RS_USE_I2P_SAM3
+		RS_USE_I2P_SAM3_LIBSAM3
+	)
+endif()
+
+################################################################################
+### rnp / openpgpsdk
+
+if(RS_RNPLIB)
+	find_package(rnp REQUIRED)
+
+	target_link_libraries(${PROJECT_NAME} PRIVATE rnp::librnp)
+else()
+	find_package(openpgpsdk REQUIRED)
+
+	target_link_libraries(${PROJECT_NAME} PRIVATE openpgpsdk::openpgpsdk)
+
+	target_compile_definitions(${PROJECT_NAME} PUBLIC USE_OPENPGPSDK)
+endif(RS_RNPLIB)
+
+################################################################################
+### bitdht
+
+if(RS_BITDHT)
+	find_package(bitdht REQUIRED)
+
+	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_BITDHT)
+	target_link_libraries(${PROJECT_NAME} PRIVATE bitdht)
+
+	if(RS_BITDHT_STUNNER)
+		target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_DHT_STUNNER)
+
+		if(RS_BITDHT_STUNNER_EXT_IP)
+			# TODO: Refactor this define to use proper prefix and then flag as public
+			target_compile_definitions(${PROJECT_NAME} PRIVATE ALLOW_DHT_STUNNER)
+		endif(RS_BITDHT_STUNNER_EXT_IP)
+	endif(RS_BITDHT_STUNNER)
+endif(RS_BITDHT)
+
+################################################################################
+### RapidJSON
+
+find_package(RapidJSON REQUIRED)
+target_link_libraries(${PROJECT_NAME} PUBLIC RapidJSON)
+get_target_property(tmp RapidJSON INTERFACE_INCLUDE_DIRECTORIES)
+message(STATUS "rapidjson interface: ${tmp}")
+
+################################################################################
+### SQLite3 / SQLCipher
+
+## TODO: Check if https://github.com/rbock/sqlpp11 or
+## https://github.com/rbock/sqlpp17 may improve GXS code
+if(RS_SQLCIPHER)
+	find_package(SQLCipher REQUIRED)
+	target_link_libraries(${PROJECT_NAME} PRIVATE SQLCipher::SQLCipher)
+else()
+	# TODO: Refactor this define to use proper prefix and then flag as
+	# public
+	target_compile_definitions(${PROJECT_NAME} PRIVATE NO_SQLCIPHER)
+	find_package(SQLite3 REQUIRED)
+	target_link_libraries(${PROJECT_NAME} PRIVATE SQLite::SQLite3)
+endif()
+
+################################################################################
+### UPnP
+
+if(RS_MINIUPNPC)
+	find_package(MiniUPnPc REQUIRED)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_LIBMINIUPNPC)
+	target_link_libraries(${PROJECT_NAME} PRIVATE MiniUPnPc::MiniUPnPc)
+endif(RS_MINIUPNPC)
+
+if(RS_LIBUPNP)
+	message(FATAL_ERROR "UPnP support via libupnp is currently not supported")
+	#target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_LIBUPNP)
+endif(RS_LIBUPNP)
+
+################################################################################
+### UDP-Discovery
+
+if(RS_BRODCAST_DISCOVERY)
+	find_package(udp-discovery-cpp REQUIRED)
+	target_link_libraries(${PROJECT_NAME} PRIVATE
+		udp-discovery-cpp::udp-discovery
+	)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_BROADCAST_DISCOVERY)
+endif(RS_BRODCAST_DISCOVERY)
+
+################################################################################
+### cpptrace
+
+if(RS_CPPTRACE_STACKTRACE)
+	find_package(cpptrace REQUIRED)
+	target_link_libraries(${PROJECT_NAME} PRIVATE cpptrace::cpptrace)
+	target_compile_definitions(${PROJECT_NAME} PRIVATE RS_JEREMY_RIFKIN_CPPTRACE)
+endif(RS_CPPTRACE_STACKTRACE)
+
+################################################################################
+### Platforms
+
+### Linux
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+	target_compile_definitions(${PROJECT_NAME} PUBLIC
+		RS_DATA_DIR="${RS_DATA_DIR}"
+	)
+endif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+
+### Windows
 if(WIN32)
 	target_compile_definitions(
 		${PROJECT_NAME} PUBLIC
@@ -292,662 +542,78 @@ if(WIN32)
 		NOCRYPT
 		# Prevents <windows.h> from including extra headers and polluting the namespace
 		WIN32_LEAN_AND_MEAN
-		WIN_DLL_EXPORT )
+		WIN_DLL_EXPORT
+	)
 	target_link_libraries(${PROJECT_NAME} PUBLIC ws2_32 winmm iphlpapi)
+
+	if(BUILD_SHARED_LIBS)
+		set_target_properties(${PROJECT_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+		if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+			# We must use an explicit list of heavy 3rd-party archives instead of "ALL" for --exclude-libs.
+			# Using "ALL" also hides symbols from CMake's internal objects.a archive (created by WINDOWS_EXPORT_ALL_SYMBOLS),
+			# which prevents libretroshare from exporting its own core C++ symbols, causing massive linkage errors downstream.
+			target_link_options(${PROJECT_NAME} PRIVATE "-Wl,--export-all-symbols,--exclude-libs,libbitdht.a:librnp.a:libsexpp.a:libudp-discovery.a:librestbed.a:libsqlcipher.a:libbotan-2.a:libbotan-3.a:libz.a:libbz2.a")
+		endif()
+	endif()
+
+	# Disabling LTO (Interprocedural Optimization) on Windows is necessary for RetroShare
+	# because enabling it causes the MinGW linker (ld) to run out of memory or exhaust the maximum
+	# number of exported symbols, or emit "multiple definition" errors during LTO code generation.
+	# While this makes the binary fatter and slower, it prevents fatal build failures.
+	set_property(TARGET ${PROJECT_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION OFF)
 endif()
 
-## As of today libretroshare doesn't hide implementation details properly so it
-## is necessary to flag all implementation headers as public
-target_include_directories(
-	${PROJECT_NAME}
-	PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src" )
-
-set_target_properties(
-	${PROJECT_NAME}
-	PROPERTIES PUBLIC_HEADER "${RS_PUBLIC_HEADERS}" )
-
-if(RS_LIBRETROSHARE_STANDALONE_INSTALL)
-	install(
-		TARGETS ${PROJECT_NAME}
-		LIBRARY DESTINATION "${RS_LIB_INSTALL_DIR}"
-		PUBLIC_HEADER DESTINATION "${RS_INCLUDE_INSTALL_DIR}" )
-
-	## As of today libretroshare doesn't hide implementation details properly so it
-	## is necessary to install private headers too
-	foreach(P_HEADER ${RS_IMPLEMENTATION_HEADERS})
-		get_filename_component(P_DIR "${P_HEADER}" DIRECTORY)
-		install(
-			FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/${P_HEADER}"
-			DESTINATION "${RS_INCLUDE_INSTALL_DIR}/${P_DIR}" )
-	endforeach()
-endif(RS_LIBRETROSHARE_STANDALONE_INSTALL)
-
-if(RS_SPLIT_DEBUG)
-	target_compile_options(${PROJECT_NAME} PRIVATE "-g")
-	target_compile_options(${PROJECT_NAME} PRIVATE "-gsplit-dwarf")
-endif(RS_SPLIT_DEBUG)
-
-if(RS_DEVELOPMENT_BUILD)
-	target_compile_options(${PROJECT_NAME} PRIVATE "-O0")
-endif(RS_DEVELOPMENT_BUILD)
-
-if(RS_ANDROID)
-	target_link_libraries(${PROJECT_NAME} PRIVATE log)
-endif(RS_ANDROID)
-
-
-target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
-
-find_package(Threads REQUIRED)
-target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
-
-find_package(OpenSSL REQUIRED)
-target_include_directories(${PROJECT_NAME} PRIVATE ${OPENSSL_INCLUDE_DIR})
-target_link_libraries(${PROJECT_NAME} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
-
-## bzip2 is referenced directly by libretroshare (e.g. BZ2_bzlibVersion in
-## rsserver/p3face-info.cc) and transitively by several statically-linked
-## dependencies (librnp, openpgpsdk, sqlcipher). It must be linked
-## explicitly.
-find_package(BZip2 REQUIRED)
-target_include_directories(${PROJECT_NAME} PRIVATE ${BZIP2_INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} PRIVATE BZip2::BZip2)
-
-## Link explicitly for the same reason as bzip2
-find_package(ZLIB REQUIRED)
-target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)
-
-################################################################################
-if(RS_RNPLIB)
-	## json-c is referenced transitively by librnp (json-utils.cpp,
-	## rnp.cpp, stream-dump.cpp) but not exported by librnp's CMake target.
-	find_package(json-c REQUIRED)
-	target_link_libraries(${PROJECT_NAME} PRIVATE json-c::json-c)
-
-	macro(rnplib_set_inline_build_options)
-		set(RNPLIB_BUILD_SHARED ${RS_LIBRETROSHARE_SHARED})
-		set(SAVED_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
-		set(BUILD_TESTING OFF)
-		set(BUILD_SHARED_LIBS ${RNPLIB_BUILD_SHARED})
-		set(DOWNLOAD_GTEST OFF)
-		set(ENABLE_DOC OFF CACHE BOOL "Disable librnp docs" FORCE)
-	endmacro()
-
-	macro(rnplib_restore_build_options)
-		set(BUILD_SHARED_LIBS ${SAVED_BUILD_SHARED_LIBS})
-	endmacro()
-
-	set(RNPLIB_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../supportlibs/librnp/")
-
-	if(EXISTS "${RNPLIB_DEVEL_DIR}/CMakeLists.txt")
-		message(STATUS "librnp source found at ${RNPLIB_DEVEL_DIR} using it")
-		rnplib_set_inline_build_options()
-		add_subdirectory("${RNPLIB_DEVEL_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/librnp")
-		rnplib_restore_build_options()
-		set(RNPLIB_SRC_DIR "${RNPLIB_DEVEL_DIR}")
-		set(RNPLIB_BIN_DIR "${CMAKE_CURRENT_BINARY_DIR}/librnp")
-		set(RNPLIB_INLINE_BUILD ON)
-	else()
-		find_library(LIBRNP_LIBRARY NAMES rnp)
-		if(LIBRNP_LIBRARY)
-			message(STATUS "Found pre-built librnp at ${LIBRNP_LIBRARY}")
-			find_library(LIBSEXPP_LIBRARY NAMES sexpp)
-			target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBRNP_LIBRARY})
-			if(LIBSEXPP_LIBRARY)
-				message(STATUS "and sexpp at ${LIBSEXPP_LIBRARY}")
-				target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBSEXPP_LIBRARY})
-			endif()
-			set(RNPLIB_INLINE_BUILD OFF)
-		else()
-			message(STATUS "librnp not found locally, using FetchContent")
-			rnplib_set_inline_build_options()
-			FetchContent_Declare(
-				librnp
-				GIT_REPOSITORY "https://github.com/rnpgp/rnp.git"
-				GIT_TAG "origin/main"
-				GIT_SHALLOW TRUE
-				GIT_PROGRESS TRUE
-				TIMEOUT 10
-			)
-			FetchContent_MakeAvailable(librnp)
-			rnplib_restore_build_options()
-			set(RNPLIB_SRC_DIR "${librnp_SOURCE_DIR}")
-			set(RNPLIB_BIN_DIR "${librnp_BINARY_DIR}")
-			set(RNPLIB_INLINE_BUILD ON)
-		endif()
-	endif()
-
-	if(RNPLIB_INLINE_BUILD)
-		target_include_directories(${PROJECT_NAME} PUBLIC
-			"${RNPLIB_SRC_DIR}/include"
-			"${RNPLIB_BIN_DIR}/src/lib"
-		)
-
-		if(RNPLIB_BUILD_SHARED)
-			target_link_libraries(${PROJECT_NAME} PRIVATE librnp)
-		else()
-			target_link_libraries(${PROJECT_NAME} PRIVATE librnp sexpp)
-		endif()
-	endif()
-else()
-
-	set(OPENPGPSDK_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../openpgpsdk/")
-	if(EXISTS "${OPENPGPSDK_DEVEL_DIR}/CMakeLists.txt" )
-		message(
-			STATUS
-			"openpgpsdk source found at ${OPENPGPSDK_DEVEL_DIR} using it" )
-		add_subdirectory("${OPENPGPSDK_DEVEL_DIR}" "${CMAKE_BINARY_DIR}/openpgpsdk")
-	else()
-		FetchContent_Declare(
-			openpgpsdk
-			GIT_REPOSITORY "https://github.com/RetroShare/OpenPGP-SDK.git"
-			GIT_TAG "origin/master"
-			GIT_SHALLOW TRUE
-			GIT_PROGRESS TRUE
-			TIMEOUT 10
-		)
-		FetchContent_MakeAvailable(openpgpsdk)
-	endif()
-
-	target_link_libraries(${PROJECT_NAME} PRIVATE openpgpsdk)
-
-	target_compile_definitions(${PROJECT_NAME} PUBLIC USE_OPENPGPSDK)
-
-endif(RS_RNPLIB)
-
-################################################################################
-
-if(RS_BITDHT)
-	set(BITDHT_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../libbitdht/")
-	if(EXISTS "${BITDHT_DEVEL_DIR}/CMakeLists.txt" )
-		message(
-			STATUS
-			"BitDHT submodule found at ${BITDHT_DEVEL_DIR} using it" )
-		add_subdirectory(${BITDHT_DEVEL_DIR} ${CMAKE_BINARY_DIR}/bitdht)
-		set(RS_BITDHT_DIR "${BITDHT_DEVEL_DIR}")
-	else()
-		FetchContent_Declare(
-			bitdht
-			GIT_REPOSITORY "https://github.com/RetroShare/BitDHT.git"
-			GIT_TAG "origin/master"
-			GIT_SHALLOW TRUE
-			GIT_PROGRESS TRUE
-			TIMEOUT 10
-		)
-		FetchContent_MakeAvailable(bitdht)
-
-		set(RS_BITDHT_DIR "${bitdht_SOURCE_DIR}")
-	endif()
-
-	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_BITDHT)
-	target_link_libraries(${PROJECT_NAME} PRIVATE bitdht)
-
-	if(RS_BITDHT_STUNNER)
-		target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_DHT_STUNNER)
-
-		if(RS_BITDHT_STUNNER_EXT_IP)
-			# TODO: Refactor this define to use proper prefix and then flag as
-			# public
-			target_compile_definitions(
-				${PROJECT_NAME} PRIVATE ALLOW_DHT_STUNNER )
-		endif(RS_BITDHT_STUNNER_EXT_IP)
-	endif(RS_BITDHT_STUNNER)
-endif(RS_BITDHT)
-
-################################################################################
-
-set(RAPIDJSON_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../supportlibs/rapidjson/")
-find_path(
-	RS_RAPIDJSON_INCLUDE "rapidjson/document.h"
-	PATH_SUFFIXES "include" "includes" )
-if(EXISTS "${RS_RAPIDJSON_INCLUDE}")
-	message( STATUS
-	         "RapidJSON found in system at ${RS_RAPIDJSON_INCLUDE}" )
-	target_include_directories(
-		${PROJECT_NAME}
-		PUBLIC "${RS_RAPIDJSON_INCLUDE}" )
-elseif(EXISTS "${RAPIDJSON_DEVEL_DIR}/CMakeLists.txt")
-	message( STATUS
-	         "RapidJSON found in development dir at ${RAPIDJSON_DEVEL_DIR}" )
-	target_include_directories(
-		${PROJECT_NAME}
-		PUBLIC "${RAPIDJSON_DEVEL_DIR}/include" )
-else()
-	FetchContent_Declare(
-		rapidjson
-		GIT_REPOSITORY "https://github.com/Tencent/rapidjson.git"
-		GIT_SHALLOW TRUE
-		GIT_PROGRESS TRUE
-		TIMEOUT 10
-	)
-	FetchContent_MakeAvailable(rapidjson)
-endif()
-
-################################################################################
-
-if(RS_JSON_API)
-	find_package(Doxygen REQUIRED)
-	find_package(Python3 REQUIRED)
-
-	set(
-		JSON_API_GENERATOR_WORK_DIR
-		"${CMAKE_BINARY_DIR}/jsonapi-generator.workdir/" )
-
-	set(
-		JSON_API_GENERATOR_DOXYFILE
-		"${JSON_API_GENERATOR_WORK_DIR}/jsonapi-generator-doxygen.conf" )
-
-	set(
-		JSONAPI_GENERATOR_OUTPUT_DIR
-		"${JSON_API_GENERATOR_WORK_DIR}/src/" )
-
-	set(
-		JSONAPI_GENERATOR_SOURCE_DIR
-		"${CMAKE_CURRENT_SOURCE_DIR}/src/jsonapi/" )
-
-	set(
-		JSONAPI_GENERATOR_EXECUTABLE
-		"${JSONAPI_GENERATOR_SOURCE_DIR}/jsonapi-generator.py" )
-
-	file(READ "src/jsonapi/jsonapi-generator-doxygen.conf" DOXYFILE_CONTENT)
-	string(APPEND DOXYFILE_CONTENT
-		"\nOUTPUT_DIRECTORY=${JSONAPI_GENERATOR_OUTPUT_DIR}\n"
-		"INPUT=${CMAKE_CURRENT_SOURCE_DIR}/src/\n"
-		"EXCLUDE="
-		"	${CMAKE_CURRENT_SOURCE_DIR}/src/tests"
-		"	${CMAKE_CURRENT_SOURCE_DIR}/src/unused"
-		"	${CMAKE_CURRENT_SOURCE_DIR}/src/unfinished\n"
-	)
-	file(WRITE "${JSON_API_GENERATOR_DOXYFILE}" "${DOXYFILE_CONTENT}")
-
-	add_custom_command(
-		OUTPUT
-			"${JSONAPI_GENERATOR_OUTPUT_DIR}/jsonapi-includes.inl"
-			"${JSONAPI_GENERATOR_OUTPUT_DIR}/jsonapi-wrappers.inl"
-		COMMAND ${DOXYGEN_EXECUTABLE} ${JSON_API_GENERATOR_DOXYFILE}
-		COMMAND
-			${Python3_EXECUTABLE} ${JSONAPI_GENERATOR_EXECUTABLE}
-			${JSONAPI_GENERATOR_SOURCE_DIR} ${JSONAPI_GENERATOR_OUTPUT_DIR}
-		MAIN_DEPENDENCY "${JSONAPI_GENERATOR_EXECUTABLE}"
-		DEPENDS ${JSON_API_GENERATOR_DOXYFILE} ${RS_PUBLIC_HEADERS} )
-
-	target_sources(
-		${PROJECT_NAME} PRIVATE
-		"${JSONAPI_GENERATOR_OUTPUT_DIR}/jsonapi-includes.inl"
-		"${JSONAPI_GENERATOR_OUTPUT_DIR}/jsonapi-wrappers.inl" )
-
-	target_include_directories(
-		${PROJECT_NAME} PRIVATE "${JSONAPI_GENERATOR_OUTPUT_DIR}" )
-
-	set(BUILD_TESTS OFF CACHE BOOL "Do not build restbed tests")
-	set(BUILD_SSL OFF CACHE BOOL "Do not build restbed SSL support")
-	set(BUILD_SHARED_LIBRARY ${RS_LIBRETROSHARE_SHARED})
-	set(BUILD_SHARED_LIBS ${RS_LIBRETROSHARE_SHARED})
-
-	set(RESTBED_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../supportlibs/restbed/")
-	if(RS_ANDROID)
-		## At moment depending on restbed the CMake way doesn't seems to work at
-		## least on Android due to upstream CMake file limitation, patches
-		## should be sent upstream.
-		## Restbed is therefore compiled by Android toolchain preparation script
-		target_link_libraries(${PROJECT_NAME} PRIVATE restbed)
-	elseif(NOT WIN32 AND EXISTS "${RESTBED_DEVEL_DIR}/CMakeLists.txt")
-		## On Windows, skip the local submodule: recent restbed HEAD requires
-		## system ASIO (not available by default on MSYS2/MinGW). Fall through
-		## to FetchContent which downloads restbed 4.8 with bundled ASIO.
-		message( STATUS
-		         "Restbed submodule found at ${RESTBED_DEVEL_DIR} using it" )
-		add_subdirectory(
-			${RESTBED_DEVEL_DIR}
-			${CMAKE_BINARY_DIR}/restbed
-			EXCLUDE_FROM_ALL )
-		# EXCLUDE_FROM_ALL prevent executing install directives from included
-		# dependencies see https://stackoverflow.com/a/64900982
-
-		set(RESTBED_TARGET restbed-static)
-		if(TARGET restbed-shared AND BUILD_SHARED_LIBS)
-			set(RESTBED_TARGET restbed-shared)
-		endif()
-
-		target_include_directories(
-			${PROJECT_NAME} PUBLIC "${RESTBED_DEVEL_DIR}/source/" )
-		target_link_libraries(${PROJECT_NAME} PRIVATE ${RESTBED_TARGET})
-	else()
-		message( WARNING
-		         "FetchContent restbed, will be installed if you run make install")
-		FetchContent_Declare(
-			restbed
-			GIT_REPOSITORY "https://github.com/Corvusoft/restbed.git"
-			GIT_TAG "4.8"
-			GIT_SUBMODULES dependency/asio dependency/catch
-			GIT_SHALLOW TRUE
-			GIT_PROGRESS TRUE
-			TIMEOUT 10
-			# PATCH_COMMAND applies hotfixes to restbed before building:
-			# 1. Removes /wd4251 (MSVC-specific flag) that breaks GCC/Clang builds.
-			# 2. Bumps CMake minimum version to 3.5.0 to suppress deprecation warnings in CMake >= 3.27.
-			PATCH_COMMAND sed -i -e "s|/wd4251||g" -e "s|VERSION 3.1.0|VERSION 3.5.0|g" CMakeLists.txt
-		)
-		FetchContent_MakeAvailable(restbed)
-
-		set(RESTBED_TARGET restbed-static)
-		if(TARGET restbed-shared AND BUILD_SHARED_LIBS)
-			set(RESTBED_TARGET restbed-shared)
-		endif()
-
-		target_include_directories(
-			${PROJECT_NAME} PUBLIC ${restbed_SOURCE_DIR}/source/ )
-		target_link_libraries(${PROJECT_NAME} PRIVATE ${RESTBED_TARGET})
-		if(WIN32)
-			if(TARGET restbed-static)
-				target_link_libraries(restbed-static PUBLIC ws2_32 winmm iphlpapi mswsock)
-			endif()
-			if(TARGET restbed-shared)
-				target_link_libraries(restbed-shared PUBLIC ws2_32 winmm iphlpapi mswsock)
-			endif()
-		endif()
-	endif()
-
-
-	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_JSONAPI)
-endif(RS_JSON_API)
-
-################################################################################
-
-if(RS_FORUM_DEEP_INDEX)
-	find_package(Xapian REQUIRED)
-	target_link_libraries(${PROJECT_NAME} PRIVATE ${XAPIAN_LIBRARIES})
-
-	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_DEEP_FORUMS_INDEX)
-endif(RS_FORUM_DEEP_INDEX)
-
-################################################################################
-
-## TODO: Check if https://github.com/rbock/sqlpp11 or
-## https://github.com/rbock/sqlpp17 may improve GXS code
-if(RS_SQLCIPHER)
-	find_library(RS_SQL_LIB "sqlcipher" REQUIRED)
-	find_path(
-		RS_SQL_LIB_INCLUDE "sqlcipher/sqlite3.h"
-		PATH_SUFFIXES "include" "includes"
-		REQUIRED )
-	target_include_directories(
-		${PROJECT_NAME}
-		PRIVATE "${RS_SQL_LIB_INCLUDE}/sqlcipher" )
-	target_link_libraries(${PROJECT_NAME} PRIVATE ${RS_SQL_LIB})
-else()
-	# TODO: Refactor this define to use proper prefix and then flag as
-	# public
-	target_compile_definitions(${PROJECT_NAME} PRIVATE NO_SQLCIPHER)
-	find_package(SQLite3 REQUIRED)
-	target_link_libraries(${PROJECT_NAME} PRIVATE SQLite::SQLite3)
-endif()
-
-target_compile_definitions(
-	${PROJECT_NAME} PRIVATE
-	SQLITE_HAS_CODEC
-	RS_ENABLE_GXS
-	GXS_ENABLE_SYNC_MSGS
-	RS_USE_GXS_DISTANT_SYNC
-	RS_GXS_TRANS
-	V07_NON_BACKWARD_COMPATIBLE_CHANGE_001
-	V07_NON_BACKWARD_COMPATIBLE_CHANGE_002
-	V07_NON_BACKWARD_COMPATIBLE_CHANGE_003 )
-
-if(RS_V07_BREAKING_CHANGES)
-	target_compile_definitions(
-		${PROJECT_NAME} PRIVATE
-		V07_NON_BACKWARD_COMPATIBLE_CHANGE_004
-		V07_NON_BACKWARD_COMPATIBLE_CHANGE_UNNAMED )
-endif()
-
-if(NOT RS_DH_PRIME_INIT_CHECK)
-	target_compile_definitions(
-		${PROJECT_NAME} PRIVATE RS_DISABLE_DIFFIE_HELLMAN_INIT_CHECK )
-endif(NOT RS_DH_PRIME_INIT_CHECK)
-
-if(RS_MINIUPNPC)
-	target_compile_definitions(
-		${PROJECT_NAME} PUBLIC RS_USE_LIBMINIUPNPC )
-	target_link_libraries(${PROJECT_NAME} PRIVATE miniupnpc)
-endif(RS_MINIUPNPC)
-
-if(RS_LIBUPNP)
-	message(FATAL_ERROR "UPnP support via libupnp is currently not supported")
-	#target_compile_definitions(${PROJECT_NAME} PUBLIC RS_USE_LIBUPNP)
-endif(RS_LIBUPNP)
-
-if(RS_GXS_SEND_ALL)
-	target_compile_definitions(
-		${PROJECT_NAME} PUBLIC RS_GXS_SEND_ALL )
-endif(RS_GXS_SEND_ALL)
-
-if(RS_USE_CALENDAR)
-	target_compile_definitions(
-		${PROJECT_NAME} PUBLIC RS_USE_CALENDAR )
-endif(RS_USE_CALENDAR)
-
-# Enable the experimental GXS Wiki (WikiPoos) service. The define is PUBLIC so
-# that consumers (retroshare-gui, retroshare-service) that link libretroshare
-# see the same RS_USE_WIKI guard used in rsserver/rsinit.cc and the GUI.
-if(RS_GXSWIKIPOS)
-	target_compile_definitions(
-		${PROJECT_NAME} PUBLIC RS_USE_WIKI )
-endif(RS_GXSWIKIPOS)
-
-# Enable the experimental GXS 'The Wire' service (see note above).
-if(RS_GXSTHEWIRE)
-	target_compile_definitions(
-		${PROJECT_NAME} PUBLIC RS_USE_WIRE )
-endif(RS_GXSTHEWIRE)
-
-if(RS_BRODCAST_DISCOVERY)
-	## TODO: upstream option to disable tests building
-	set(BUILD_EXAMPLE OFF CACHE BOOL "Do not build udp-discovery-cpp examples")
-	set(BUILD_TOOL OFF CACHE BOOL "Do not build udp-discovery-tool application")
-
-	set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
-
-	set(UDP_DISCOVERY_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../supportlibs/udp-discovery-cpp/")
-	if(EXISTS "${UDP_DISCOVERY_DEVEL_DIR}/CMakeLists.txt")
-		message( STATUS
-		         "UDP discovery source found at ${UDP_DISCOVERY_DEVEL_DIR} using it" )
-		add_subdirectory(${UDP_DISCOVERY_DEVEL_DIR} ${CMAKE_BINARY_DIR}/udp-discovery-cpp/)
-
-		## TODO: Temporary work around target_include_directories PUBLIC should
-		## be added upstream
-		target_include_directories(
-			${PROJECT_NAME} PRIVATE "${UDP_DISCOVERY_DEVEL_DIR}" )
-	else()
-		FetchContent_Declare(
-			udp-discovery-cpp
-			GIT_REPOSITORY "https://github.com/truvorskameikin/udp-discovery-cpp.git"
-			GIT_TAG "origin/master"
-			GIT_SHALLOW TRUE
-			GIT_PROGRESS TRUE
-			TIMEOUT 10
-		)
-		FetchContent_MakeAvailable(udp-discovery-cpp)
-
-		## TODO: Temporary work around target_include_directories PUBLIC should
-		## be added upstream
-		target_include_directories(
-			${PROJECT_NAME} PRIVATE "${udp-discovery-cpp_SOURCE_DIR}" )
-	endif()
-
-	target_link_libraries(${PROJECT_NAME} PRIVATE udp-discovery)
-
-	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_BROADCAST_DISCOVERY)
-endif(RS_BRODCAST_DISCOVERY)
-
-if(NOT RS_WARN_DEPRECATED)
-	target_compile_definitions(${PROJECT_NAME} PRIVATE RS_NO_WARN_DEPRECATED)
-	target_compile_options(
-		${PROJECT_NAME} PRIVATE
-		-Wno-deprecated -Wno-deprecated-declarations )
-endif(NOT RS_WARN_DEPRECATED)
-
-if(RS_WARN_LESS)
-	target_compile_definitions(${PROJECT_NAME} PRIVATE RS_NO_WARN_CPP)
-
-	target_compile_options(
-		${PROJECT_NAME} PRIVATE
-		-Wno-cpp -Wno-inconsistent-missing-override )
-endif(RS_WARN_LESS)
-
-if(RS_WEBUI)
-	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_WEBUI)
-endif(RS_WEBUI)
-
-################################################################################
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-	target_compile_definitions(
-		${PROJECT_NAME} PUBLIC RS_DATA_DIR="${RS_DATA_DIR}" )
-endif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-
-################################################################################
-
+### Mac
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	target_link_libraries(${PROJECT_NAME} PRIVATE "-framework Cocoa")
 endif()
 
-################################################################################
-
-if(RS_EXPORT_JNI_ONLOAD)
-	target_compile_definitions(
-		${PROJECT_NAME} PUBLIC RS_LIBRETROSHARE_EXPORT_JNI_ONLOAD )
-endif(RS_EXPORT_JNI_ONLOAD)
-
-################################################################################
-
+### Android
 if(RS_ANDROID)
-	FetchContent_Declare(
-		jni-hpp
-		GIT_REPOSITORY "https://github.com/RetroShare/jni.hpp.git"
-		GIT_TAG "origin/master"
-		GIT_SHALLOW TRUE
-		GIT_PROGRESS TRUE
-		TIMEOUT 10
-	)
-	FetchContent_MakeAvailable(jni-hpp)
-
-	target_include_directories(
-		${PROJECT_NAME} PRIVATE "${jni-hpp_SOURCE_DIR}/include" )
-endif(RS_ANDROID)
-
-################################################################################
-
-
-set(V_VERSION_SET OFF)
-
-if( NOT RS_MAJOR_VERSION STREQUAL "" AND
-    NOT RS_MINOR_VERSION STREQUAL "" AND
-    NOT RS_MINI_VERSION  STREQUAL "" )
-	message(STATUS "libRetroShare version ${RS_MAJOR_VERSION}.${RS_MINOR_VERSION}.${RS_MINI_VERSION}${RS_EXTRA_VERSION} defined in command line")
-	set(V_VERSION_SET ON)
-else()
-	set(V_GIT_DESCRIBE_OUTPUT "")
-	set(V_GIT_DESCRIBE_REGEXP "^v([0-9]+).([0-9]+).([0-9]+)(.*)\n$")
-
-	execute_process(
-		COMMAND ${GIT_EXECUTABLE} describe --tags --long --match v*.*.*
-		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-		OUTPUT_VARIABLE V_GIT_DESCRIBE_OUTPUT
-		RESULT_VARIABLE V_GIT_RESULT ) # Avoid CMake failure if git fails
-
-	if( V_GIT_RESULT EQUAL 0 AND
-	    V_GIT_DESCRIBE_OUTPUT MATCHES "${V_GIT_DESCRIBE_REGEXP}" )
-		string(
-			REGEX REPLACE
-			"${V_GIT_DESCRIBE_REGEXP}" "\\1;\\2;\\3;\\4"
-			V_GIT_DESCRIBE_LIST ${V_GIT_DESCRIBE_OUTPUT} )
-		list(GET V_GIT_DESCRIBE_LIST 0 RS_MAJOR_VERSION)
-		list(GET V_GIT_DESCRIBE_LIST 1 RS_MINOR_VERSION)
-		list(GET V_GIT_DESCRIBE_LIST 2 RS_MINI_VERSION)
-		list(GET V_GIT_DESCRIBE_LIST 3 RS_EXTRA_VERSION)
-
-		message("libRetroShare version ${RS_MAJOR_VERSION}.${RS_MINOR_VERSION}.${RS_MINI_VERSION}${RS_EXTRA_VERSION} determined via git")
-		set(V_VERSION_SET ON)
-	else()
-		message(WARNING "Determining libRetroShare version via git failed please specify it through CMake command line arguments!")
+	target_link_libraries(${PROJECT_NAME} PRIVATE log)
+	if(BUILD_SHARED_LIBS)
+		target_link_options(${PROJECT_NAME} PRIVATE LINKER:--no-undefined)
 	endif()
-endif()
 
-if(V_VERSION_SET)
-	target_compile_definitions(
-		${PROJECT_NAME}
-		PUBLIC RS_MAJOR_VERSION=${RS_MAJOR_VERSION}
-		PUBLIC RS_MINOR_VERSION=${RS_MINOR_VERSION}
-		PUBLIC RS_MINI_VERSION=${RS_MINI_VERSION}
-		PUBLIC RS_EXTRA_VERSION="${RS_EXTRA_VERSION}" )
-endif(V_VERSION_SET)
+	## On Android all symbols except for the few ones used called via JNI can be
+	## kept hidden allowing for more optimization, and reduced binary size
+	# TODO: Use generator expressions instead of CMAKE_BUILD_TYPE see
+	# https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#build-configurations
+	# https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#manual:cmake-generator-expressions(7)
+	if(CMAKE_BUILD_TYPE STREQUAL "Release")
+		set_property(TARGET ${PROJECT_NAME} PROPERTY C_VISIBILITY_PRESET hidden)
+		set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_VISIBILITY_PRESET hidden)
+		set_property(TARGET ${PROJECT_NAME} PROPERTY VISIBILITY_INLINES_HIDDEN ON)
+	endif()
 
-################################################################################
-
-# Engine build hash exposed through RsInit::libRetroShareVersion().
-# Ported from the qmake build (libretroshare.pro RS_LIB_VERSION_HASH block):
-# describe the libretroshare submodule itself and drop the leading 'v' to
-# match the GUI version style. Used only inside libretroshare, hence PRIVATE.
-execute_process(
-	COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty
-	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-	OUTPUT_VARIABLE RS_LIB_VERSION_HASH
-	OUTPUT_STRIP_TRAILING_WHITESPACE
-	RESULT_VARIABLE V_GIT_HASH_RESULT ) # Avoid CMake failure if git fails
-
-if(V_GIT_HASH_RESULT EQUAL 0 AND NOT RS_LIB_VERSION_HASH STREQUAL "")
-	string(REGEX REPLACE "^v" "" RS_LIB_VERSION_HASH "${RS_LIB_VERSION_HASH}")
-	message(STATUS "libRetroShare engine hash ${RS_LIB_VERSION_HASH}")
-	target_compile_definitions(
-		${PROJECT_NAME}
-		PRIVATE RS_LIB_VERSION_HASH="${RS_LIB_VERSION_HASH}" )
-else()
-	message(WARNING "Determining libRetroShare engine hash via git failed")
+	find_package(jni.hpp REQUIRED)
+	target_link_libraries(${PROJECT_NAME} PRIVATE jni.hpp::jni.hpp)
 endif()
 
 ################################################################################
+### subdirectories
 
-# TODO: Use generator expressions instead of CMAKE_BUILD_TYPE see
-# https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#build-configurations
-# https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#manual:cmake-generator-expressions(7)
-
-## On Android all symbols except for the few ones used called via JNI can be
-## kept hidden allowing for more optimization, and reduced binary size
-if(RS_ANDROID AND CMAKE_BUILD_TYPE STREQUAL "Release")
-	set_property(TARGET ${PROJECT_NAME} PROPERTY C_VISIBILITY_PRESET hidden)
-	set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_VISIBILITY_PRESET hidden)
-	set_property(TARGET ${PROJECT_NAME} PROPERTY VISIBILITY_INLINES_HIDDEN ON)
-endif()
-
-# Note: Disabling LTO (Interprocedural Optimization) on Windows is necessary for RetroShare 
-# because enabling it causes the MinGW linker (ld) to run out of memory or exhaust the maximum
-# number of exported symbols, or emit "multiple definition" errors during LTO code generation. 
-# While this makes the binary fatter and slower, it prevents fatal build failures.
-# The same escape hatch (-DRS_NO_LTO=ON) also works around lto1 internal compiler
-# errors (segfault in the IPA icf pass) with the older GCC 10 LTO plugin, e.g. when
-# building on Debian 11 to produce a portable (old-glibc) AppImage.
-if(CMAKE_BUILD_TYPE STREQUAL "Release" AND NOT WIN32 AND NOT RS_NO_LTO)
-	set_property(TARGET ${PROJECT_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION ON)
-endif()
+add_subdirectory(src)
 
 ################################################################################
+### install
 
-if(RS_CPPTRACE_STACKTRACE)
-    FetchContent_Declare(
-      cpptrace
-      GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
-      GIT_TAG v0.3.1
-      GIT_SHALLOW TRUE
-      GIT_PROGRESS TRUE
-      TIMEOUT 10
-    )
-    FetchContent_MakeAvailable(cpptrace)
-    target_link_libraries(${PROJECT_NAME} PRIVATE cpptrace::cpptrace)
-    target_compile_definitions(
-        ${LIBRARY_NAME} PRIVATE RS_JEREMY_RIFKIN_CPPTRACE )
-endif(RS_CPPTRACE_STACKTRACE)
+install(
+	TARGETS ${PROJECT_NAME}
+	COMPONENT libretroshare
+	EXCLUDE_FROM_ALL
+	LIBRARY DESTINATION "${RS_LIB_INSTALL_DIR}"
+	PUBLIC_HEADER DESTINATION "${RS_INCLUDE_INSTALL_DIR}"
+)
 
-if(RS_USE_I2P_SAM3)
-	target_link_libraries(${PROJECT_NAME} PRIVATE sam3)
-endif()
+## As of today libretroshare doesn't hide implementation details properly so it
+## is necessary to install private headers too
+foreach(P_HEADER ${RS_IMPLEMENTATION_HEADERS})
+	get_filename_component(P_DIR "${P_HEADER}" DIRECTORY)
+	install(
+		FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/${P_HEADER}"
+		DESTINATION "${RS_INCLUDE_INSTALL_DIR}/${P_DIR}"
+		COMPONENT libretroshare
+		EXCLUDE_FROM_ALL
+	)
+endforeach()

--- a/mk/cmake/FindMiniUPnPc.cmake
+++ b/mk/cmake/FindMiniUPnPc.cmake
@@ -32,5 +32,5 @@ find_package_handle_standard_args(MiniUPnPc
 )
 
 if(MiniUPnPc_FOUND)
-  add_library(MiniUPnPc::MiniUPnPc ALIAS PkgConfig::MiniUPnPc)
+  add_library(miniupnpc::miniupnpc ALIAS PkgConfig::MiniUPnPc)
 endif()

--- a/mk/cmake/FindMiniUPnPc.cmake
+++ b/mk/cmake/FindMiniUPnPc.cmake
@@ -1,0 +1,36 @@
+## ---------------------------------------------------------------------- ##
+ # mk/cmake/FindMiniUPnPc.cmake
+ # This file is part of libRetroShare.
+ #
+ # Copyright (C) 2026      David Bears <dbear4q@gmail.com>
+ #
+ # This program is free software; you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation; either version 2 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License along
+ # with this program; if not, write to the Free Software Foundation, Inc.,
+ # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+## ---------------------------------------------------------------------- ##
+
+find_package(PkgConfig)
+if(PkgConfig_FOUND)
+  pkg_check_modules(MiniUPnPc IMPORTED_TARGET miniupnpc)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MiniUPnPc
+  REQUIRED_VARS MiniUPnPc_FOUND
+  VERSION_VAR MiniUPnPc_VERSION
+  HANDLE_VERSION_RANGE
+)
+
+if(MiniUPnPc_FOUND)
+  add_library(MiniUPnPc::MiniUPnPc ALIAS PkgConfig::MiniUPnPc)
+endif()

--- a/mk/cmake/FindSQLCipher.cmake
+++ b/mk/cmake/FindSQLCipher.cmake
@@ -1,0 +1,36 @@
+## ---------------------------------------------------------------------- ##
+ # mk/cmake/FindSQLCipher.cmake
+ # This file is part of libRetroShare.
+ #
+ # Copyright (C) 2026      David Bears <dbear4q@gmail.com>
+ #
+ # This program is free software; you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation; either version 2 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License along
+ # with this program; if not, write to the Free Software Foundation, Inc.,
+ # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+## ---------------------------------------------------------------------- ##
+
+find_package(PkgConfig)
+if(PkgConfig_FOUND)
+  pkg_check_modules(SQLCipher IMPORTED_TARGET sqlcipher)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SQLCipher
+  REQUIRED_VARS SQLCipher_FOUND
+  VERSION_VAR SQLCipher_VERSION
+  HANDLE_VERSION_RANGE
+)
+
+if(SQLCipher_FOUND)
+  add_library(SQLCipher::SQLCipher ALIAS PkgConfig::SQLCipher)
+endif()

--- a/mk/cmake/Findrestbed.cmake
+++ b/mk/cmake/Findrestbed.cmake
@@ -1,0 +1,36 @@
+## ---------------------------------------------------------------------- ##
+ # mk/cmake/Findrestbed.cmake
+ # This file is part of libRetroShare.
+ #
+ # Copyright (C) 2026      David Bears <dbear4q@gmail.com>
+ #
+ # This program is free software; you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation; either version 2 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License along
+ # with this program; if not, write to the Free Software Foundation, Inc.,
+ # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+## ---------------------------------------------------------------------- ##
+
+find_library(RESTBED_LIBRARY NAMES restbed)
+find_path(RESTBED_INCLUDE NAMES restbed)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(restbed
+  REQUIRED_VARS RESTBED_LIBRARY RESTBED_INCLUDE
+)
+
+if(restbed_FOUND AND NOT TARGET restbed::restbed)
+  add_library(restbed::restbed UNKNOWN IMPORTED)
+  set_target_properties(restbed::restbed PROPERTIES
+    IMPORTED_LOCATION "${RESTBED_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${RESTBED_INCLUDE}"
+  )
+endif()

--- a/mk/cmake/Findudp-discovery-cpp.cmake
+++ b/mk/cmake/Findudp-discovery-cpp.cmake
@@ -1,0 +1,44 @@
+## ---------------------------------------------------------------------- ##
+ # mk/cmake/Findudp-discovery-cpp.cmake
+ # This file is part of libRetroShare.
+ #
+ # Copyright (C) 2026      David Bears <dbear4q@gmail.com>
+ #
+ # This program is free software; you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation; either version 2 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License along
+ # with this program; if not, write to the Free Software Foundation, Inc.,
+ # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+## ---------------------------------------------------------------------- ##
+
+find_library(udp-discovery_LIBRARY NAMES udp-discovery)
+find_path(udp-discovery_INCLUDE NAMES udp_discovery_peer.hpp)
+find_program(udp-discovery_TOOL NAMES udp-discovery-tool)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(udp-discovery-cpp
+  REQUIRED_VARS udp-discovery_LIBRARY udp-discovery_INCLUDE
+)
+
+if(udp-discovery-cpp_FOUND AND NOT TARGET udp-discovery-cpp::udp-discovery)
+  add_library(udp-discovery-cpp::udp-discovery STATIC IMPORTED)
+  set_target_properties(udp-discovery-cpp::udp-discovery PROPERTIES
+    IMPORTED_LOCATION "${udp-discovery_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${udp-discovery_INCLUDE}"
+  )
+endif()
+
+if(udp-discovery_TOOL AND NOT TARGET udp-discovery-tool)
+  add_executable(udp-discovery-cpp::udp-discovery-tool IMPORTED)
+  set_target_properties(udp-discovery-cpp::udp-discovery-tool PROPERTIES
+    IMPORTED_LOCATION "${udp-discovery_TOOL}"
+  )
+endif()

--- a/mk/cmake/GetGitRevisionDescription.cmake
+++ b/mk/cmake/GetGitRevisionDescription.cmake
@@ -1,0 +1,288 @@
+# source: https://github.com/rpavlik/cmake-modules
+# - Returns a version string from Git
+#
+# These functions force a re-configure on each git commit so that you can
+# trust the values of the variables in your build system.
+#
+#  get_git_head_revision(<refspecvar> <hashvar> [ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR])
+#
+# Returns the refspec and sha hash of the current head revision
+#
+#  git_describe(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe on the source tree, and adjusting
+# the output so that it tests false if an error occurs.
+#
+#  git_describe_working_tree(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe on the working tree (--dirty option),
+# and adjusting the output so that it tests false if an error occurs.
+#
+#  git_get_exact_tag(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe --exact-match on the source tree,
+# and adjusting the output so that it tests false if there was no exact
+# matching tag.
+#
+#  git_local_changes(<var>)
+#
+# Returns either "CLEAN" or "DIRTY" with respect to uncommitted changes.
+# Uses the return code of "git diff-index --quiet HEAD --".
+# Does not regard untracked files.
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2020 Rylie Pavlik <rylie@ryliepavlik.com>
+# https://ryliepavlik.com/
+#
+# Copyright 2009-2013, Iowa State University.
+# Copyright 2013-2020, Rylie Pavlik
+# Copyright 2013-2020, Contributors
+#
+# SPDX-License-Identifier: BSL-1.0
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(__get_git_revision_description)
+    return()
+endif()
+set(__get_git_revision_description YES)
+
+# We must run the following at "include" time, not at function call time,
+# to find the path to this module rather than the path to a calling list file
+get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
+
+# Function _git_find_closest_git_dir finds the next closest .git directory
+# that is part of any directory in the path defined by _start_dir.
+# The result is returned in the parent scope variable whose name is passed
+# as variable _git_dir_var. If no .git directory can be found, the
+# function returns an empty string via _git_dir_var.
+#
+# Example: Given a path C:/bla/foo/bar and assuming C:/bla/.git exists and
+# neither foo nor bar contain a file/directory .git. This wil return
+# C:/bla/.git
+#
+function(_git_find_closest_git_dir _start_dir _git_dir_var)
+    set(cur_dir "${_start_dir}")
+    set(git_dir "${_start_dir}/.git")
+    while(NOT EXISTS "${git_dir}")
+        # .git dir not found, search parent directories
+        set(git_previous_parent "${cur_dir}")
+        get_filename_component(cur_dir "${cur_dir}" DIRECTORY)
+        if(cur_dir STREQUAL git_previous_parent)
+            # We have reached the root directory, we are not in git
+            set(${_git_dir_var}
+                ""
+                PARENT_SCOPE)
+            return()
+        endif()
+        set(git_dir "${cur_dir}/.git")
+    endwhile()
+    set(${_git_dir_var}
+        "${git_dir}"
+        PARENT_SCOPE)
+endfunction()
+
+function(get_git_head_revision _refspecvar _hashvar)
+    _git_find_closest_git_dir("${CMAKE_CURRENT_SOURCE_DIR}" GIT_DIR)
+
+    if("${ARGN}" STREQUAL "ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR")
+        set(ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR TRUE)
+    else()
+        set(ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR FALSE)
+    endif()
+    if(NOT "${GIT_DIR}" STREQUAL "")
+        file(RELATIVE_PATH _relative_to_source_dir "${CMAKE_SOURCE_DIR}"
+             "${GIT_DIR}")
+        if("${_relative_to_source_dir}" MATCHES "[.][.]"
+           AND NOT ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR)
+            # We've gone above the CMake root dir.
+            set(GIT_DIR "")
+        endif()
+    endif()
+    if("${GIT_DIR}" STREQUAL "")
+        set(${_refspecvar}
+            "GITDIR-NOTFOUND"
+            PARENT_SCOPE)
+        set(${_hashvar}
+            "GITDIR-NOTFOUND"
+            PARENT_SCOPE)
+        return()
+    endif()
+
+    # Check if the current source dir is a git submodule or a worktree.
+    # In both cases .git is a file instead of a directory.
+    #
+    if(NOT IS_DIRECTORY ${GIT_DIR})
+        # The following git command will return a non empty string that
+        # points to the super project working tree if the current
+        # source dir is inside a git submodule.
+        # Otherwise the command will return an empty string.
+        #
+        execute_process(
+            COMMAND "${GIT_EXECUTABLE}" rev-parse
+                    --show-superproject-working-tree
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+            OUTPUT_VARIABLE out
+            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+        if(NOT "${out}" STREQUAL "")
+            # If out is empty, GIT_DIR/CMAKE_CURRENT_SOURCE_DIR is in a submodule
+            file(READ ${GIT_DIR} submodule)
+            string(REGEX REPLACE "gitdir: (.*)$" "\\1" GIT_DIR_RELATIVE
+                                 ${submodule})
+            string(STRIP ${GIT_DIR_RELATIVE} GIT_DIR_RELATIVE)
+            get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
+            get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE}
+                                   ABSOLUTE)
+            set(HEAD_SOURCE_FILE "${GIT_DIR}/HEAD")
+        else()
+            # GIT_DIR/CMAKE_CURRENT_SOURCE_DIR is in a worktree
+            file(READ ${GIT_DIR} worktree_ref)
+            # The .git directory contains a path to the worktree information directory
+            # inside the parent git repo of the worktree.
+            #
+            string(REGEX REPLACE "gitdir: (.*)$" "\\1" git_worktree_dir
+                                 ${worktree_ref})
+            string(STRIP ${git_worktree_dir} git_worktree_dir)
+            _git_find_closest_git_dir("${git_worktree_dir}" GIT_DIR)
+            set(HEAD_SOURCE_FILE "${git_worktree_dir}/HEAD")
+        endif()
+    else()
+        set(HEAD_SOURCE_FILE "${GIT_DIR}/HEAD")
+    endif()
+    set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
+    if(NOT EXISTS "${GIT_DATA}")
+        file(MAKE_DIRECTORY "${GIT_DATA}")
+    endif()
+
+    if(NOT EXISTS "${HEAD_SOURCE_FILE}")
+        return()
+    endif()
+    set(HEAD_FILE "${GIT_DATA}/HEAD")
+    configure_file("${HEAD_SOURCE_FILE}" "${HEAD_FILE}" COPYONLY)
+
+    configure_file("${_gitdescmoddir}/GetGitRevisionDescription.cmake.in"
+                   "${GIT_DATA}/grabRef.cmake" @ONLY)
+    include("${GIT_DATA}/grabRef.cmake")
+
+    set(${_refspecvar}
+        "${HEAD_REF}"
+        PARENT_SCOPE)
+    set(${_hashvar}
+        "${HEAD_HASH}"
+        PARENT_SCOPE)
+endfunction()
+
+function(git_describe _var)
+    if(NOT GIT_FOUND)
+        find_package(Git QUIET)
+    endif()
+    get_git_head_revision(refspec hash)
+    if(NOT GIT_FOUND)
+        set(${_var}
+            "GIT-NOTFOUND"
+            PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT hash)
+        set(${_var}
+            "HEAD-HASH-NOTFOUND"
+            PARENT_SCOPE)
+        return()
+    endif()
+
+    # TODO sanitize
+    #if((${ARGN}" MATCHES "&&") OR
+    #	(ARGN MATCHES "||") OR
+    #	(ARGN MATCHES "\\;"))
+    #	message("Please report the following error to the project!")
+    #	message(FATAL_ERROR "Looks like someone's doing something nefarious with git_describe! Passed arguments ${ARGN}")
+    #endif()
+
+    #message(STATUS "Arguments to execute_process: ${ARGN}")
+
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" describe --tags --always ${hash} ${ARGN}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE res
+        OUTPUT_VARIABLE out
+        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT res EQUAL 0)
+        set(out "${out}-${res}-NOTFOUND")
+    endif()
+
+    set(${_var}
+        "${out}"
+        PARENT_SCOPE)
+endfunction()
+
+function(git_describe_working_tree _var)
+    if(NOT GIT_FOUND)
+        find_package(Git QUIET)
+    endif()
+    if(NOT GIT_FOUND)
+        set(${_var}
+            "GIT-NOTFOUND"
+            PARENT_SCOPE)
+        return()
+    endif()
+
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" describe --dirty ${ARGN}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE res
+        OUTPUT_VARIABLE out
+        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT res EQUAL 0)
+        set(out "${out}-${res}-NOTFOUND")
+    endif()
+
+    set(${_var}
+        "${out}"
+        PARENT_SCOPE)
+endfunction()
+
+function(git_get_exact_tag _var)
+    git_describe(out --exact-match ${ARGN})
+    set(${_var}
+        "${out}"
+        PARENT_SCOPE)
+endfunction()
+
+function(git_local_changes _var)
+    if(NOT GIT_FOUND)
+        find_package(Git QUIET)
+    endif()
+    get_git_head_revision(refspec hash)
+    if(NOT GIT_FOUND)
+        set(${_var}
+            "GIT-NOTFOUND"
+            PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT hash)
+        set(${_var}
+            "HEAD-HASH-NOTFOUND"
+            PARENT_SCOPE)
+        return()
+    endif()
+
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" diff-index --quiet HEAD --
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE res
+        OUTPUT_VARIABLE out
+        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(res EQUAL 0)
+        set(${_var}
+            "CLEAN"
+            PARENT_SCOPE)
+    else()
+        set(${_var}
+            "DIRTY"
+            PARENT_SCOPE)
+    endif()
+endfunction()

--- a/mk/cmake/GetGitRevisionDescription.cmake.in
+++ b/mk/cmake/GetGitRevisionDescription.cmake.in
@@ -1,0 +1,49 @@
+# source: https://github.com/rpavlik/cmake-modules
+#
+# Internal file for GetGitRevisionDescription.cmake
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2023 Rylie Pavlik <rylie@ryliepavlik.com>
+# https://ryliepavlik.com/
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright 2009-2012, Iowa State University
+# Copyright 2011-2023, Contributors
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+# SPDX-License-Identifier: BSL-1.0
+
+set(HEAD_HASH)
+
+file(READ "@HEAD_FILE@" HEAD_CONTENTS LIMIT 1024)
+
+string(STRIP "${HEAD_CONTENTS}" HEAD_CONTENTS)
+if(HEAD_CONTENTS MATCHES "ref")
+    # named branch
+    string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
+    if(EXISTS "@GIT_DIR@/${HEAD_REF}")
+        configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
+    else()
+        if(EXISTS "@GIT_DIR@/packed-refs")
+            configure_file("@GIT_DIR@/packed-refs" "@GIT_DATA@/packed-refs"
+                           COPYONLY)
+            file(READ "@GIT_DATA@/packed-refs" PACKED_REFS)
+            if(${PACKED_REFS} MATCHES "([0-9a-z]*) ${HEAD_REF}")
+                set(HEAD_HASH "${CMAKE_MATCH_1}")
+            endif()
+        endif()
+    endif()
+else()
+    # detached HEAD
+    configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
+endif()
+
+if(NOT HEAD_HASH)
+    file(READ "@GIT_DATA@/head-ref" HEAD_HASH LIMIT 1024)
+    string(STRIP "${HEAD_HASH}" HEAD_HASH)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -871,7 +871,6 @@ endif(RS_JSON_API)
 
 target_sources(${PROJECT_NAME}
 	PUBLIC FILE_SET HEADERS
-	BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
 	FILES
   ${RS_PUBLIC_HEADERS}
 	## libretroshare doesn't hide implementation details properly so it

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,12 @@ target_sources(${PROJECT_NAME}
 
 	PRIVATE FILE_SET private_HEADERS TYPE HEADERS
 	BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
-
-	PRIVATE FILE_SET SOURCES
 )
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+	target_sources(${PROJECT_NAME}
+		PRIVATE FILE_SET SOURCES
+	)
+endif()
 
 list(APPEND RS_PUBLIC_HEADERS
 	retroshare/rsexpr.h
@@ -874,8 +877,16 @@ target_sources(${PROJECT_NAME}
 	## libretroshare doesn't hide implementation details properly so it
 	## is necessary to flag all implementation headers as public.
 	${RS_IMPLEMENTATION_HEADERS}
-
-	PRIVATE FILE_SET SOURCES
-	FILES
-	${RS_SOURCES}
 )
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+	target_sources(${PROJECT_NAME}
+		PRIVATE FILE_SET SOURCES
+		FILES
+		${RS_SOURCES}
+	)
+else()
+	target_sources(${PROJECT_NAME}
+		PRIVATE
+		${RS_SOURCES}
+	)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,21 @@
 # RetroShare decentralized communication platform
 #
-# Copyright (C) 2021  Gioacchino Mazzurco <gio@retroshare.cc>
+# Copyright (C) 2021      Gioacchino Mazzurco <gio@retroshare.cc>
+# Copyright (C) 2026      David Bears <dbear4q@gmail.com>
 #
 # SPDX-License-Identifier: CC0-1.0
 
-list(
-	APPEND RS_PUBLIC_HEADERS
+target_sources(${PROJECT_NAME}
+	PUBLIC FILE_SET HEADERS
+	BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+
+	PRIVATE FILE_SET private_HEADERS TYPE HEADERS
+	BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+
+	PRIVATE FILE_SET SOURCES
+)
+
+list(APPEND RS_PUBLIC_HEADERS
 	retroshare/rsexpr.h
 	retroshare/rsgxsdistsync.h
 	retroshare/rsiface.h
@@ -25,7 +35,7 @@ list(
 	retroshare/rsreputations.h
 	retroshare/rsservicecontrol.h
 	retroshare/rstokenservice.h
-	retroshare/rsturtle.h	
+	retroshare/rsturtle.h
 	retroshare/rsgossipdiscovery.h
 	retroshare/rsgxscommon.h
 	retroshare/rsposted.h
@@ -46,59 +56,58 @@ list(
 	retroshare/rsfiles.h
 	retroshare/rsinit.h
 	retroshare/rspeers.h
-	retroshare/rstor.h )
+	retroshare/rstor.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	chat/distantchat.cc
 	chat/p3chatservice.cc
 	chat/rschatitems.cc
-	chat/distributedchat.cc )
+	chat/distributedchat.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	chat/distantchat.h
 	chat/distributedchat.h
 	chat/p3chatservice.h
-	chat/rschatitems.h )
+	chat/rschatitems.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	crypto/chacha20.cpp
 	crypto/hashstream.cc
 	crypto/rsaes.cc
-	crypto/rscrypto.cpp )
+	crypto/rscrypto.cpp
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	crypto/chacha20.h
 	crypto/hashstream.h
 	crypto/rsaes.h
 	crypto/rscrypto.h )
 
 if(RS_BITDHT)
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rsdht.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rsdht.h
+	)
 
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		dht/connectstatebox.cc
 		dht/p3bitdht.cc
 		dht/p3bitdht_interface.cc
 		dht/p3bitdht_peernet.cc
 		dht/p3bitdht_peers.cc
-		dht/p3bitdht_relay.cc )
+		dht/p3bitdht_relay.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		dht/connectstatebox.h
 		dht/p3bitdht.h
-		dht/stunaddrassist.h )
+		dht/stunaddrassist.h
+	)
 endif(RS_BITDHT)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	file_sharing/filelist_io.cc
 	file_sharing/rsfilelistitems.cc
 	file_sharing/file_tree.cc
@@ -116,10 +125,10 @@ list(
 	ft/ftcontroller.cc
 	ft/ftdatamultiplex.cc
 	ft/ftextralist.cc
-	ft/ftserver.cc )
+	ft/ftserver.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	file_sharing/directory_list.h
 	file_sharing/directory_storage.h
 	file_sharing/directory_updater.h
@@ -140,25 +149,25 @@ list(
 	ft/ftsearch.h
 	ft/ftserver.h
 	ft/fttransfermodule.h
-	ft/ftturtlefiletransferitem.h )
+	ft/ftturtlefiletransferitem.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	grouter/groutermatrix.cc
 	grouter/grouteritems.cc
-	grouter/p3grouter.cc )
+	grouter/p3grouter.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	grouter/groutercache.h
 	grouter/grouterclientservice.h
 	grouter/grouteritems.h
 	grouter/groutermatrix.h
 	grouter/groutertypes.h
-	grouter/p3grouter.h )
+	grouter/p3grouter.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	gxs/rsgxsdata.cc
 	gxs/rsgxsrequesttypes.cc
 	gxs/gxssecurity.cc
@@ -170,10 +179,10 @@ list(
 	gxs/rsgxsutil.cc
 	gxs/rsnxsobserver.cpp
 	gxs/rsgenexchange.cc
-	gxs/rsgxsnetservice.cc )
+	gxs/rsgxsnetservice.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	gxs/gxssecurity.h
 	gxs/gxstokenqueue.h
 	gxs/rsdataservice.h
@@ -191,83 +200,95 @@ list(
 	gxs/rsgxsrequesttypes.h
 	gxs/rsgxsutil.h
 	gxs/rsnxs.h
-	gxs/rsnxsobserver.h )
+	gxs/rsnxsobserver.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	gxstrans/p3gxstransitems.cc
-	gxstrans/p3gxstrans.cc )
+	gxstrans/p3gxstrans.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	gxstrans/p3gxstrans.h
-	gxstrans/p3gxstransitems.h )
+	gxstrans/p3gxstransitems.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	gxstunnel/rsgxstunnelitems.cc
-	gxstunnel/p3gxstunnel.cc )
+	gxstunnel/p3gxstunnel.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	gxstunnel/p3gxstunnel.h
-	gxstunnel/rsgxstunnelitems.h )
+	gxstunnel/rsgxstunnelitems.h
+)
 
 if(RS_JSON_API)
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rsjsonapi.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rsjsonapi.h
+	)
 
-	list(
-		APPEND RS_SOURCES
-		jsonapi/jsonapi.cpp )
+	list(APPEND RS_SOURCES
+		jsonapi/jsonapi.cpp
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		jsonapi/jsonapi.h
-		jsonapi/jsonapiitems.h )
+		jsonapi/jsonapiitems.h
+	)
 endif(RS_JSON_API)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	pgp/pgpauxutils.cc
 	pgp/pgphandler.cc
 	pgp/pgpkeyutil.cc
-	pgp/rscertificate.cc )
+	pgp/rscertificate.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	pgp/pgpauxutils.h
 	pgp/pgphandler.h
 	pgp/pgpkeyutil.h
-	pgp/rscertificate.h )
+	pgp/rscertificate.h
+)
 
 if(RS_RNPLIB)
-	list(APPEND RS_SOURCES pgp/rnppgphandler.cc)
-	list(APPEND RS_IMPLEMENTATION_HEADERS pgp/rnppgphandler.h)
+	list(APPEND RS_SOURCES
+		pgp/rnppgphandler.cc
+	)
+	list(APPEND RS_IMPLEMENTATION_HEADERS
+		pgp/rnppgphandler.h
+	)
 else()
-	list(APPEND RS_SOURCES pgp/openpgpsdkhandler.cc)
-	list(APPEND RS_IMPLEMENTATION_HEADERS pgp/openpgpsdkhandler.h)
+	list(APPEND RS_SOURCES
+		pgp/openpgpsdkhandler.cc
+	)
+	list(APPEND RS_IMPLEMENTATION_HEADERS
+		pgp/openpgpsdkhandler.h
+	)
 endif()
 
 #./plugins/rscacheservice.h
 #./plugins/rspqiservice.h
 
 if(WIN32)
-	list(APPEND RS_SOURCES plugins/dlfcn_win32.cc)
-	list(APPEND RS_IMPLEMENTATION_HEADERS plugins/dlfcn_win32.h)
+	list(APPEND RS_SOURCES
+		plugins/dlfcn_win32.cc
+	)
+	list(APPEND RS_IMPLEMENTATION_HEADERS
+		plugins/dlfcn_win32.h
+	)
 endif()
 
-list(
-	APPEND RS_SOURCES
-	plugins/pluginmanager.cc )
+list(APPEND RS_SOURCES
+	plugins/pluginmanager.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
-	plugins/pluginmanager.h )
+list(APPEND RS_IMPLEMENTATION_HEADERS
+	plugins/pluginmanager.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	pqi/pqibin.cc
 	pqi/pqiipset.cc
 	pqi/pqiloopback.cc
@@ -297,10 +318,10 @@ list(
 	pqi/p3peermgr.cc
 	pqi/pqinetwork.cc
 	pqi/pqissl.cc
-	pqi/pqisslpersongrp.cc )
+	pqi/pqisslpersongrp.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	pqi/authgpg.h
 	pqi/authssl.h
 	pqi/p3cfgmgr.h
@@ -339,7 +360,9 @@ list(
 	pqi/pqistore.h
 	pqi/pqistreamer.h
 	pqi/pqithreadstreamer.h
-	pqi/sslfns.h )
+	pqi/sslfns.h
+)
+
 if(RS_USE_I2P_SAM3)
 	list(APPEND RS_SOURCES
 		pqi/pqissli2psam3.cpp
@@ -348,8 +371,8 @@ if(RS_USE_I2P_SAM3)
 		pqi/pqissli2psam3.h
 	)
 endif()
-list(
-	APPEND RS_SOURCES
+
+list(APPEND RS_SOURCES
 	rsitems/rsbanlistitems.cc
 	rsitems/rsbwctrlitems.cc
 	rsitems/rsconfigitems.cc
@@ -362,25 +385,25 @@ list(
 	rsitems/rsgxsupdateitems.cc
 	rsitems/rshistoryitems.cc
 	rsitems/rsrttitems.cc
-	rsitems/rsserviceinfoitems.cc )
+	rsitems/rsserviceinfoitems.cc
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	rsitems/rsgxschannelitems.cc
 	rsitems/rsgxscircleitems.cc
 	rsitems/rsgxsitems.cc
-	rsitems/rsmsgitems.cc )
+	rsitems/rsmsgitems.cc
+)
 
 #./rsitems/rsphotoitems.cc
 #./rsitems/rsphotoitems.h
 #./rsitems/rsposteditems.h
 
-list(
-	APPEND RS_SOURCES
-	rsitems/rsnxsitems.cc )
+list(APPEND RS_SOURCES
+	rsitems/rsnxsitems.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	rsitems/itempriorities.h
 	rsitems/rsbanlistitems.h
 	rsitems/rsbwctrlitems.h
@@ -405,10 +428,10 @@ list(
 	rsitems/rsrttitems.h
 	rsitems/rsserviceids.h
 	rsitems/rsserviceinfoitems.h
-	rsitems/rsstatusitems.h )
+	rsitems/rsstatusitems.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	rsserver/p3status.cc
 	rsserver/p3face-config.cc
 	rsserver/p3face-info.cc
@@ -418,20 +441,20 @@ list(
 	rsserver/p3face-server.cc
 	rsserver/p3peers.cc
 	rsserver/rsaccounts.cc
-	rsserver/rsinit.cc )
+	rsserver/rsinit.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	rsserver/p3face.h
 	rsserver/p3history.h
 	rsserver/p3peers.h
 	rsserver/p3serverconfig.h
 	rsserver/p3status.h
 	rsserver/rsaccounts.h
-	rsserver/rsloginhandler.h )
+	rsserver/rsloginhandler.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	serialiser/rsbaseserial.cc
 	serialiser/rsserializable.cc
 	serialiser/rstlvaddrs.cc
@@ -449,10 +472,10 @@ list(
 	serialiser/rstlvstring.cc
 	serialiser/rsserializer.cc
 	serialiser/rstypeserializer.cc
-	serialiser/rsserial.cc )
+	serialiser/rsserial.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	serialiser/rsbaseserial.h
 	serialiser/rsserial.h
 	serialiser/rsserializable.h
@@ -473,7 +496,9 @@ list(
 	serialiser/rstlvlist.h
 	serialiser/rstlvmaps.h
 	serialiser/rstlvstring.h
-	serialiser/rstypeserializer.h )
+	serialiser/rstypeserializer.h
+)
+
 # ./services/autoproxy
 if(RS_USE_I2P_SAM3)
 	list(APPEND RS_SOURCES
@@ -483,8 +508,7 @@ if(RS_USE_I2P_SAM3)
 		services/autoproxy/p3i2psam3.h
 	)
 endif()
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	services/autoproxy/rsautoproxymonitor.cc
 	services/p3bwctrl.cc
 	services/p3heartbeat.cc
@@ -500,10 +524,10 @@ list(
 	services/p3msgservice.cc
 	services/p3idservice.cc
 	services/p3gxschannels.cc
-	services/p3gxsforums.cc )
+	services/p3gxsforums.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	services/p3banlist.h
 	services/p3bwctrl.h
 	services/p3gxschannels.h
@@ -520,129 +544,123 @@ list(
 	services/p3service.h
 	services/p3serviceinfo.h
 	services/p3statusservice.h
-	services/rseventsservice.h )
+	services/rseventsservice.h
+)
 
 if(RS_USE_CALENDAR)
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rsgxscalendar.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rsgxscalendar.h
+	)
 
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		rsitems/rsgxscalendaritems.cc
-		services/p3gxscalendar.cc )
+		services/p3gxscalendar.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		rsitems/rsgxscalendaritems.h
-		services/p3gxscalendar.h )
+		services/p3gxscalendar.h
+	)
 endif(RS_USE_CALENDAR)
-	
-# The Wiki (WikiPoos) and The Wire are experimental, off-by-default GXS
-# services. Their sources are compiled only when the matching option is set.
-# The options live in the top-level CMakeLists.txt (RS_GXSWIKIPOS /
-# RS_GXSTHEWIRE), which also adds the RS_USE_WIKI / RS_USE_WIRE compile
-# definitions that gate the service instantiation in rsserver/rsinit.cc and
-# the corresponding GUI code.
+
 if(RS_GXSWIKIPOS)
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		services/p3wiki.cc
-		rsitems/rswikiitems.cc )
+		rsitems/rswikiitems.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		services/p3wiki.h
-		rsitems/rswikiitems.h )
+		rsitems/rswikiitems.h
+	)
 
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rswiki.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rswiki.h
+	)
 endif(RS_GXSWIKIPOS)
 
 if(RS_GXSTHEWIRE)
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		services/p3wire.cc
-		rsitems/rswireitems.cc )
+		rsitems/rswireitems.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		services/p3wire.h
-		rsitems/rswireitems.h )
+		rsitems/rswireitems.h
+	)
 
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rswire.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rswire.h
+	)
 endif(RS_GXSTHEWIRE)
 
 #./services/p3photoservice.cc
 #./services/p3photoservice.h
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	services/p3postbase.cc
 	services/p3posted.cc
-	rsitems/rsposteditems.cc )
+	rsitems/rsposteditems.cc
+)
 
 if(RS_BRODCAST_DISCOVERY)
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rsbroadcastdiscovery.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rsbroadcastdiscovery.h
+	)
 
-	list(
-		APPEND RS_SOURCES
-		services/broadcastdiscoveryservice.cc )
+	list(APPEND RS_SOURCES
+		services/broadcastdiscoveryservice.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
-		services/broadcastdiscoveryservice.h )
+	list(APPEND RS_IMPLEMENTATION_HEADERS
+		services/broadcastdiscoveryservice.h
+	)
 endif(RS_BRODCAST_DISCOVERY)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	tcponudp/tcppacket.cc
 	tcponudp/tcpstream.cc
 	tcponudp/tou.cc
 	tcponudp/udppeer.cc
 	tcponudp/bss_tou.cc
-	tcponudp/udprelay.cc )
+	tcponudp/udprelay.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	tcponudp/bio_tou.h
 	tcponudp/rsudpstack.h
 	tcponudp/tcppacket.h
 	tcponudp/tcpstream.h
 	tcponudp/tou.h
 	tcponudp/udppeer.h
-	tcponudp/udprelay.h )
+	tcponudp/udprelay.h
+)
 
 if(RS_BITDHT_STUNNER)
-	list(
-		APPEND RS_SOURCES
-		tcponudp/udpstunner.cc )
+	list(APPEND RS_SOURCES
+		tcponudp/udpstunner.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
-		tcponudp/udpstunner.h )
+	list(APPEND RS_IMPLEMENTATION_HEADERS
+		tcponudp/udpstunner.h
+	)
 endif(RS_BITDHT_STUNNER)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	turtle/rsturtleitem.cc
-	turtle/p3turtle.cc )
+	turtle/p3turtle.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	turtle/p3turtle.h
 	turtle/rsturtleitem.h
 	turtle/turtleclientservice.h
 	turtle/turtlestatistics.h
-	turtle/turtletypes.h )
+	turtle/turtletypes.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	util/contentvalue.cc
 	util/rsdbbind.cc
 	util/rsdiscspace.cc
@@ -670,10 +688,10 @@ list(
 	util/rsnet_ss.cc
 	util/rsstacktrace.cc
 	util/rsthreads.cc
-	util/i2pcommon.cpp )
+	util/i2pcommon.cpp
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	util/i2pcommon.h
 	util/argstream.h
 	util/contentvalue.h
@@ -721,18 +739,19 @@ list(
 	util/rsurl.h
 	util/rswin.h
 	util/smallobject.h
-	util/stacktrace.h )
+	util/stacktrace.h
+)
 
 if(RS_FORUM_DEEP_INDEX)
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		deep_search/commonutils.cpp
-		deep_search/forumsindex.cpp )
+		deep_search/forumsindex.cpp
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		deep_search/commonutils.hpp
-		deep_search/forumsindex.hpp )
+		deep_search/forumsindex.hpp
+	)
 endif(RS_FORUM_DEEP_INDEX)
 
 
@@ -744,52 +763,50 @@ endif(RS_FORUM_DEEP_INDEX)
 #./deep_search/channelsindex.cpp
 #./deep_search/channelsindex.hpp
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	gossipdiscovery/gossipdiscoveryitems.cc
-	gossipdiscovery/p3gossipdiscovery.cc )
+	gossipdiscovery/p3gossipdiscovery.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	gossipdiscovery/gossipdiscoveryitems.h
-	gossipdiscovery/p3gossipdiscovery.h )
+	gossipdiscovery/p3gossipdiscovery.h
+)
 
 if(RS_MINIUPNPC)
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		rs_upnp/upnphandler_miniupnp.cc
-		rs_upnp/upnputil.cc )
+		rs_upnp/upnputil.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		rs_upnp/upnphandler_miniupnp.h
-		rs_upnp/upnputil.h )
+		rs_upnp/upnputil.h
+	)
 endif(RS_MINIUPNPC)
 
 #./rs_upnp/UPnPBase.cpp
 #./rs_upnp/upnphandler_libupnp.cc
 #./rs_upnp/upnptest.cc
 
-#if(CMAKE_SYSTEM_NAME STREQUAL "Android")
 if(RS_ANDROID)
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		rs_android/errorconditionwrap.cpp
 		rs_android/retroshareserviceandroid.cpp
-		rs_android/rsjni.cpp )
+		rs_android/rsjni.cpp
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		rs_android/androidcoutcerrcatcher.hpp
 		rs_android/ifaddrs-android.h
 		rs_android/LocalArray.h
 		rs_android/retroshareserviceandroid.hpp
 		rs_android/rsjni.hpp
-		rs_android/ScopedFd.h )
+		rs_android/ScopedFd.h
+	)
 endif()
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	pqi/rstcpsocket.cc
 	pqi/pqiproxy.cc
 	tor/AddOnionCommand.cpp
@@ -805,10 +822,10 @@ list(
 	tor/TorControlCommand.cpp
 	tor/TorControlSocket.cpp
 	tor/TorProcess.cpp
-	tor/TorManager.cpp )
+	tor/TorManager.cpp
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	pqi/pqiproxy.h
 	pqi/rstcpsocket.h
 	tor/AddOnionCommand.h
@@ -827,18 +844,38 @@ list(
 	tor/TorManager.h
 	tor/TorProcess.h
 	tor/TorTypes.h
-	tor/Useful.h )
+	tor/Useful.h
+)
 
 if(RS_WEBUI)
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rswebui.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rswebui.h
+	)
 
-	list(
-		APPEND RS_SOURCES
-		jsonapi/p3webui.cc )
+	list(APPEND RS_SOURCES
+		jsonapi/p3webui.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
-		jsonapi/p3webui.h )
+	list(APPEND RS_IMPLEMENTATION_HEADERS
+		jsonapi/p3webui.h
+	)
 endif(RS_WEBUI)
+
+if(RS_JSON_API)
+	add_subdirectory(jsonapi)
+endif(RS_JSON_API)
+
+
+target_sources(${PROJECT_NAME}
+	PUBLIC FILE_SET HEADERS
+	BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+	FILES
+  ${RS_PUBLIC_HEADERS}
+	## libretroshare doesn't hide implementation details properly so it
+	## is necessary to flag all implementation headers as public.
+	${RS_IMPLEMENTATION_HEADERS}
+
+	PRIVATE FILE_SET SOURCES
+	FILES
+	${RS_SOURCES}
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,21 @@
 # RetroShare decentralized communication platform
 #
-# Copyright (C) 2021  Gioacchino Mazzurco <gio@retroshare.cc>
+# Copyright (C) 2021      Gioacchino Mazzurco <gio@retroshare.cc>
+# Copyright (C) 2026      David Bears <dbear4q@gmail.com>
 #
 # SPDX-License-Identifier: CC0-1.0
 
-list(
-	APPEND RS_PUBLIC_HEADERS
+target_sources(${PROJECT_NAME}
+	PUBLIC FILE_SET HEADERS
+	BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+
+	PRIVATE FILE_SET private_HEADERS TYPE HEADERS
+	BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+
+	PRIVATE FILE_SET SOURCES
+)
+
+list(APPEND RS_PUBLIC_HEADERS
 	retroshare/rsexpr.h
 	retroshare/rsgxsdistsync.h
 	retroshare/rsiface.h
@@ -25,7 +35,7 @@ list(
 	retroshare/rsreputations.h
 	retroshare/rsservicecontrol.h
 	retroshare/rstokenservice.h
-	retroshare/rsturtle.h	
+	retroshare/rsturtle.h
 	retroshare/rsgossipdiscovery.h
 	retroshare/rsgxscommon.h
 	retroshare/rsposted.h
@@ -46,59 +56,58 @@ list(
 	retroshare/rsfiles.h
 	retroshare/rsinit.h
 	retroshare/rspeers.h
-	retroshare/rstor.h )
+	retroshare/rstor.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	chat/distantchat.cc
 	chat/p3chatservice.cc
 	chat/rschatitems.cc
-	chat/distributedchat.cc )
+	chat/distributedchat.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	chat/distantchat.h
 	chat/distributedchat.h
 	chat/p3chatservice.h
-	chat/rschatitems.h )
+	chat/rschatitems.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	crypto/chacha20.cpp
 	crypto/hashstream.cc
 	crypto/rsaes.cc
-	crypto/rscrypto.cpp )
+	crypto/rscrypto.cpp
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	crypto/chacha20.h
 	crypto/hashstream.h
 	crypto/rsaes.h
 	crypto/rscrypto.h )
 
 if(RS_BITDHT)
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rsdht.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rsdht.h
+	)
 
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		dht/connectstatebox.cc
 		dht/p3bitdht.cc
 		dht/p3bitdht_interface.cc
 		dht/p3bitdht_peernet.cc
 		dht/p3bitdht_peers.cc
-		dht/p3bitdht_relay.cc )
+		dht/p3bitdht_relay.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		dht/connectstatebox.h
 		dht/p3bitdht.h
-		dht/stunaddrassist.h )
+		dht/stunaddrassist.h
+	)
 endif(RS_BITDHT)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	file_sharing/filelist_io.cc
 	file_sharing/rsfilelistitems.cc
 	file_sharing/file_tree.cc
@@ -116,10 +125,10 @@ list(
 	ft/ftcontroller.cc
 	ft/ftdatamultiplex.cc
 	ft/ftextralist.cc
-	ft/ftserver.cc )
+	ft/ftserver.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	file_sharing/directory_list.h
 	file_sharing/directory_storage.h
 	file_sharing/directory_updater.h
@@ -140,25 +149,25 @@ list(
 	ft/ftsearch.h
 	ft/ftserver.h
 	ft/fttransfermodule.h
-	ft/ftturtlefiletransferitem.h )
+	ft/ftturtlefiletransferitem.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	grouter/groutermatrix.cc
 	grouter/grouteritems.cc
-	grouter/p3grouter.cc )
+	grouter/p3grouter.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	grouter/groutercache.h
 	grouter/grouterclientservice.h
 	grouter/grouteritems.h
 	grouter/groutermatrix.h
 	grouter/groutertypes.h
-	grouter/p3grouter.h )
+	grouter/p3grouter.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	gxs/rsgxsdata.cc
 	gxs/rsgxsrequesttypes.cc
 	gxs/gxssecurity.cc
@@ -170,10 +179,10 @@ list(
 	gxs/rsgxsutil.cc
 	gxs/rsnxsobserver.cpp
 	gxs/rsgenexchange.cc
-	gxs/rsgxsnetservice.cc )
+	gxs/rsgxsnetservice.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	gxs/gxssecurity.h
 	gxs/gxstokenqueue.h
 	gxs/rsdataservice.h
@@ -191,83 +200,95 @@ list(
 	gxs/rsgxsrequesttypes.h
 	gxs/rsgxsutil.h
 	gxs/rsnxs.h
-	gxs/rsnxsobserver.h )
+	gxs/rsnxsobserver.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	gxstrans/p3gxstransitems.cc
-	gxstrans/p3gxstrans.cc )
+	gxstrans/p3gxstrans.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	gxstrans/p3gxstrans.h
-	gxstrans/p3gxstransitems.h )
+	gxstrans/p3gxstransitems.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	gxstunnel/rsgxstunnelitems.cc
-	gxstunnel/p3gxstunnel.cc )
+	gxstunnel/p3gxstunnel.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	gxstunnel/p3gxstunnel.h
-	gxstunnel/rsgxstunnelitems.h )
+	gxstunnel/rsgxstunnelitems.h
+)
 
 if(RS_JSON_API)
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rsjsonapi.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rsjsonapi.h
+	)
 
-	list(
-		APPEND RS_SOURCES
-		jsonapi/jsonapi.cpp )
+	list(APPEND RS_SOURCES
+		jsonapi/jsonapi.cpp
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		jsonapi/jsonapi.h
-		jsonapi/jsonapiitems.h )
+		jsonapi/jsonapiitems.h
+	)
 endif(RS_JSON_API)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	pgp/pgpauxutils.cc
 	pgp/pgphandler.cc
 	pgp/pgpkeyutil.cc
-	pgp/rscertificate.cc )
+	pgp/rscertificate.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	pgp/pgpauxutils.h
 	pgp/pgphandler.h
 	pgp/pgpkeyutil.h
-	pgp/rscertificate.h )
+	pgp/rscertificate.h
+)
 
 if(RS_RNPLIB)
-	list(APPEND RS_SOURCES pgp/rnppgphandler.cc)
-	list(APPEND RS_IMPLEMENTATION_HEADERS pgp/rnppgphandler.h)
+	list(APPEND RS_SOURCES
+		pgp/rnppgphandler.cc
+	)
+	list(APPEND RS_IMPLEMENTATION_HEADERS
+		pgp/rnppgphandler.h
+	)
 else()
-	list(APPEND RS_SOURCES pgp/openpgpsdkhandler.cc)
-	list(APPEND RS_IMPLEMENTATION_HEADERS pgp/openpgpsdkhandler.h)
+	list(APPEND RS_SOURCES
+		pgp/openpgpsdkhandler.cc
+	)
+	list(APPEND RS_IMPLEMENTATION_HEADERS
+		pgp/openpgpsdkhandler.h
+	)
 endif()
 
 #./plugins/rscacheservice.h
 #./plugins/rspqiservice.h
 
 if(WIN32)
-	list(APPEND RS_SOURCES plugins/dlfcn_win32.cc)
-	list(APPEND RS_IMPLEMENTATION_HEADERS plugins/dlfcn_win32.h)
+	list(APPEND RS_SOURCES
+		plugins/dlfcn_win32.cc
+	)
+	list(APPEND RS_IMPLEMENTATION_HEADERS
+		plugins/dlfcn_win32.h
+	)
 endif()
 
-list(
-	APPEND RS_SOURCES
-	plugins/pluginmanager.cc )
+list(APPEND RS_SOURCES
+	plugins/pluginmanager.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
-	plugins/pluginmanager.h )
+list(APPEND RS_IMPLEMENTATION_HEADERS
+	plugins/pluginmanager.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	pqi/pqibin.cc
 	pqi/pqiipset.cc
 	pqi/pqiloopback.cc
@@ -297,10 +318,10 @@ list(
 	pqi/p3peermgr.cc
 	pqi/pqinetwork.cc
 	pqi/pqissl.cc
-	pqi/pqisslpersongrp.cc )
+	pqi/pqisslpersongrp.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	pqi/authgpg.h
 	pqi/authssl.h
 	pqi/p3cfgmgr.h
@@ -339,7 +360,9 @@ list(
 	pqi/pqistore.h
 	pqi/pqistreamer.h
 	pqi/pqithreadstreamer.h
-	pqi/sslfns.h )
+	pqi/sslfns.h
+)
+
 if(RS_USE_I2P_SAM3)
 	list(APPEND RS_SOURCES
 		pqi/pqissli2psam3.cpp
@@ -348,8 +371,8 @@ if(RS_USE_I2P_SAM3)
 		pqi/pqissli2psam3.h
 	)
 endif()
-list(
-	APPEND RS_SOURCES
+
+list(APPEND RS_SOURCES
 	rsitems/rsbanlistitems.cc
 	rsitems/rsbwctrlitems.cc
 	rsitems/rsconfigitems.cc
@@ -362,25 +385,25 @@ list(
 	rsitems/rsgxsupdateitems.cc
 	rsitems/rshistoryitems.cc
 	rsitems/rsrttitems.cc
-	rsitems/rsserviceinfoitems.cc )
+	rsitems/rsserviceinfoitems.cc
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	rsitems/rsgxschannelitems.cc
 	rsitems/rsgxscircleitems.cc
 	rsitems/rsgxsitems.cc
-	rsitems/rsmsgitems.cc )
+	rsitems/rsmsgitems.cc
+)
 
 #./rsitems/rsphotoitems.cc
 #./rsitems/rsphotoitems.h
 #./rsitems/rsposteditems.h
 
-list(
-	APPEND RS_SOURCES
-	rsitems/rsnxsitems.cc )
+list(APPEND RS_SOURCES
+	rsitems/rsnxsitems.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	rsitems/itempriorities.h
 	rsitems/rsbanlistitems.h
 	rsitems/rsbwctrlitems.h
@@ -405,10 +428,10 @@ list(
 	rsitems/rsrttitems.h
 	rsitems/rsserviceids.h
 	rsitems/rsserviceinfoitems.h
-	rsitems/rsstatusitems.h )
+	rsitems/rsstatusitems.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	rsserver/p3status.cc
 	rsserver/p3face-config.cc
 	rsserver/p3face-info.cc
@@ -418,20 +441,20 @@ list(
 	rsserver/p3face-server.cc
 	rsserver/p3peers.cc
 	rsserver/rsaccounts.cc
-	rsserver/rsinit.cc )
+	rsserver/rsinit.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	rsserver/p3face.h
 	rsserver/p3history.h
 	rsserver/p3peers.h
 	rsserver/p3serverconfig.h
 	rsserver/p3status.h
 	rsserver/rsaccounts.h
-	rsserver/rsloginhandler.h )
+	rsserver/rsloginhandler.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	serialiser/rsbaseserial.cc
 	serialiser/rsserializable.cc
 	serialiser/rstlvaddrs.cc
@@ -449,10 +472,10 @@ list(
 	serialiser/rstlvstring.cc
 	serialiser/rsserializer.cc
 	serialiser/rstypeserializer.cc
-	serialiser/rsserial.cc )
+	serialiser/rsserial.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	serialiser/rsbaseserial.h
 	serialiser/rsserial.h
 	serialiser/rsserializable.h
@@ -473,7 +496,9 @@ list(
 	serialiser/rstlvlist.h
 	serialiser/rstlvmaps.h
 	serialiser/rstlvstring.h
-	serialiser/rstypeserializer.h )
+	serialiser/rstypeserializer.h
+)
+
 # ./services/autoproxy
 if(RS_USE_I2P_SAM3)
 	list(APPEND RS_SOURCES
@@ -483,8 +508,7 @@ if(RS_USE_I2P_SAM3)
 		services/autoproxy/p3i2psam3.h
 	)
 endif()
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	services/autoproxy/rsautoproxymonitor.cc
 	services/p3bwctrl.cc
 	services/p3heartbeat.cc
@@ -500,10 +524,10 @@ list(
 	services/p3msgservice.cc
 	services/p3idservice.cc
 	services/p3gxschannels.cc
-	services/p3gxsforums.cc )
+	services/p3gxsforums.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	services/p3banlist.h
 	services/p3bwctrl.h
 	services/p3gxschannels.h
@@ -520,129 +544,123 @@ list(
 	services/p3service.h
 	services/p3serviceinfo.h
 	services/p3statusservice.h
-	services/rseventsservice.h )
+	services/rseventsservice.h
+)
 
 if(RS_USE_CALENDAR)
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rsgxscalendar.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rsgxscalendar.h
+	)
 
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		rsitems/rsgxscalendaritems.cc
-		services/p3gxscalendar.cc )
+		services/p3gxscalendar.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		rsitems/rsgxscalendaritems.h
-		services/p3gxscalendar.h )
+		services/p3gxscalendar.h
+	)
 endif(RS_USE_CALENDAR)
-	
-# The Wiki (WikiPoos) and The Wire are experimental, off-by-default GXS
-# services. Their sources are compiled only when the matching option is set.
-# The options live in the top-level CMakeLists.txt (RS_GXSWIKIPOS /
-# RS_GXSTHEWIRE), which also adds the RS_USE_WIKI / RS_USE_WIRE compile
-# definitions that gate the service instantiation in rsserver/rsinit.cc and
-# the corresponding GUI code.
+
 if(RS_GXSWIKIPOS)
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		services/p3wiki.cc
-		rsitems/rswikiitems.cc )
+		rsitems/rswikiitems.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		services/p3wiki.h
-		rsitems/rswikiitems.h )
+		rsitems/rswikiitems.h
+	)
 
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rswiki.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rswiki.h
+	)
 endif(RS_GXSWIKIPOS)
 
 if(RS_GXSTHEWIRE)
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		services/p3wire.cc
-		rsitems/rswireitems.cc )
+		rsitems/rswireitems.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		services/p3wire.h
-		rsitems/rswireitems.h )
+		rsitems/rswireitems.h
+	)
 
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rswire.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rswire.h
+	)
 endif(RS_GXSTHEWIRE)
 
 #./services/p3photoservice.cc
 #./services/p3photoservice.h
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	services/p3postbase.cc
 	services/p3posted.cc
-	rsitems/rsposteditems.cc )
+	rsitems/rsposteditems.cc
+)
 
 if(RS_BRODCAST_DISCOVERY)
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rsbroadcastdiscovery.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rsbroadcastdiscovery.h
+	)
 
-	list(
-		APPEND RS_SOURCES
-		services/broadcastdiscoveryservice.cc )
+	list(APPEND RS_SOURCES
+		services/broadcastdiscoveryservice.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
-		services/broadcastdiscoveryservice.h )
+	list(APPEND RS_IMPLEMENTATION_HEADERS
+		services/broadcastdiscoveryservice.h
+	)
 endif(RS_BRODCAST_DISCOVERY)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	tcponudp/tcppacket.cc
 	tcponudp/tcpstream.cc
 	tcponudp/tou.cc
 	tcponudp/udppeer.cc
 	tcponudp/bss_tou.cc
-	tcponudp/udprelay.cc )
+	tcponudp/udprelay.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	tcponudp/bio_tou.h
 	tcponudp/rsudpstack.h
 	tcponudp/tcppacket.h
 	tcponudp/tcpstream.h
 	tcponudp/tou.h
 	tcponudp/udppeer.h
-	tcponudp/udprelay.h )
+	tcponudp/udprelay.h
+)
 
 if(RS_BITDHT_STUNNER)
-	list(
-		APPEND RS_SOURCES
-		tcponudp/udpstunner.cc )
+	list(APPEND RS_SOURCES
+		tcponudp/udpstunner.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
-		tcponudp/udpstunner.h )
+	list(APPEND RS_IMPLEMENTATION_HEADERS
+		tcponudp/udpstunner.h
+	)
 endif(RS_BITDHT_STUNNER)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	turtle/rsturtleitem.cc
-	turtle/p3turtle.cc )
+	turtle/p3turtle.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	turtle/p3turtle.h
 	turtle/rsturtleitem.h
 	turtle/turtleclientservice.h
 	turtle/turtlestatistics.h
-	turtle/turtletypes.h )
+	turtle/turtletypes.h
+)
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	util/contentvalue.cc
 	util/rsdbbind.cc
 	util/rsdiscspace.cc
@@ -670,10 +688,10 @@ list(
 	util/rsnet_ss.cc
 	util/rsstacktrace.cc
 	util/rsthreads.cc
-	util/i2pcommon.cpp )
+	util/i2pcommon.cpp
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	util/i2pcommon.h
 	util/argstream.h
 	util/contentvalue.h
@@ -723,18 +741,19 @@ list(
 	util/rsurl.h
 	util/rswin.h
 	util/smallobject.h
-	util/stacktrace.h )
+	util/stacktrace.h
+)
 
 if(RS_FORUM_DEEP_INDEX)
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		deep_search/commonutils.cpp
-		deep_search/forumsindex.cpp )
+		deep_search/forumsindex.cpp
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		deep_search/commonutils.hpp
-		deep_search/forumsindex.hpp )
+		deep_search/forumsindex.hpp
+	)
 endif(RS_FORUM_DEEP_INDEX)
 
 
@@ -746,52 +765,50 @@ endif(RS_FORUM_DEEP_INDEX)
 #./deep_search/channelsindex.cpp
 #./deep_search/channelsindex.hpp
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	gossipdiscovery/gossipdiscoveryitems.cc
-	gossipdiscovery/p3gossipdiscovery.cc )
+	gossipdiscovery/p3gossipdiscovery.cc
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	gossipdiscovery/gossipdiscoveryitems.h
-	gossipdiscovery/p3gossipdiscovery.h )
+	gossipdiscovery/p3gossipdiscovery.h
+)
 
 if(RS_MINIUPNPC)
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		rs_upnp/upnphandler_miniupnp.cc
-		rs_upnp/upnputil.cc )
+		rs_upnp/upnputil.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		rs_upnp/upnphandler_miniupnp.h
-		rs_upnp/upnputil.h )
+		rs_upnp/upnputil.h
+	)
 endif(RS_MINIUPNPC)
 
 #./rs_upnp/UPnPBase.cpp
 #./rs_upnp/upnphandler_libupnp.cc
 #./rs_upnp/upnptest.cc
 
-#if(CMAKE_SYSTEM_NAME STREQUAL "Android")
 if(RS_ANDROID)
-	list(
-		APPEND RS_SOURCES
+	list(APPEND RS_SOURCES
 		rs_android/errorconditionwrap.cpp
 		rs_android/retroshareserviceandroid.cpp
-		rs_android/rsjni.cpp )
+		rs_android/rsjni.cpp
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
+	list(APPEND RS_IMPLEMENTATION_HEADERS
 		rs_android/androidcoutcerrcatcher.hpp
 		rs_android/ifaddrs-android.h
 		rs_android/LocalArray.h
 		rs_android/retroshareserviceandroid.hpp
 		rs_android/rsjni.hpp
-		rs_android/ScopedFd.h )
+		rs_android/ScopedFd.h
+	)
 endif()
 
-list(
-	APPEND RS_SOURCES
+list(APPEND RS_SOURCES
 	pqi/rstcpsocket.cc
 	pqi/pqiproxy.cc
 	tor/AddOnionCommand.cpp
@@ -807,10 +824,10 @@ list(
 	tor/TorControlCommand.cpp
 	tor/TorControlSocket.cpp
 	tor/TorProcess.cpp
-	tor/TorManager.cpp )
+	tor/TorManager.cpp
+)
 
-list(
-	APPEND RS_IMPLEMENTATION_HEADERS
+list(APPEND RS_IMPLEMENTATION_HEADERS
 	pqi/pqiproxy.h
 	pqi/rstcpsocket.h
 	tor/AddOnionCommand.h
@@ -829,18 +846,38 @@ list(
 	tor/TorManager.h
 	tor/TorProcess.h
 	tor/TorTypes.h
-	tor/Useful.h )
+	tor/Useful.h
+)
 
 if(RS_WEBUI)
-	list(
-		APPEND RS_PUBLIC_HEADERS
-		retroshare/rswebui.h )
+	list(APPEND RS_PUBLIC_HEADERS
+		retroshare/rswebui.h
+	)
 
-	list(
-		APPEND RS_SOURCES
-		jsonapi/p3webui.cc )
+	list(APPEND RS_SOURCES
+		jsonapi/p3webui.cc
+	)
 
-	list(
-		APPEND RS_IMPLEMENTATION_HEADERS
-		jsonapi/p3webui.h )
+	list(APPEND RS_IMPLEMENTATION_HEADERS
+		jsonapi/p3webui.h
+	)
 endif(RS_WEBUI)
+
+if(RS_JSON_API)
+	add_subdirectory(jsonapi)
+endif(RS_JSON_API)
+
+
+target_sources(${PROJECT_NAME}
+	PUBLIC FILE_SET HEADERS
+	BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+	FILES
+  ${RS_PUBLIC_HEADERS}
+	## libretroshare doesn't hide implementation details properly so it
+	## is necessary to flag all implementation headers as public.
+	${RS_IMPLEMENTATION_HEADERS}
+
+	PRIVATE FILE_SET SOURCES
+	FILES
+	${RS_SOURCES}
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,12 @@ target_sources(${PROJECT_NAME}
 
 	PRIVATE FILE_SET private_HEADERS TYPE HEADERS
 	BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
-
-	PRIVATE FILE_SET SOURCES
 )
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+	target_sources(${PROJECT_NAME}
+		PRIVATE FILE_SET SOURCES
+	)
+endif()
 
 list(APPEND RS_PUBLIC_HEADERS
 	retroshare/rsexpr.h
@@ -876,8 +879,16 @@ target_sources(${PROJECT_NAME}
 	## libretroshare doesn't hide implementation details properly so it
 	## is necessary to flag all implementation headers as public.
 	${RS_IMPLEMENTATION_HEADERS}
-
-	PRIVATE FILE_SET SOURCES
-	FILES
-	${RS_SOURCES}
 )
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+	target_sources(${PROJECT_NAME}
+		PRIVATE FILE_SET SOURCES
+		FILES
+		${RS_SOURCES}
+	)
+else()
+	target_sources(${PROJECT_NAME}
+		PRIVATE
+		${RS_SOURCES}
+	)
+endif()

--- a/src/jsonapi/CMakeLists.txt
+++ b/src/jsonapi/CMakeLists.txt
@@ -55,11 +55,6 @@ target_sources(${PROJECT_NAME}
   "${CMAKE_CURRENT_BINARY_DIR}/jsonapi-wrappers.inl"
 )
 
-target_include_directories(${PROJECT_NAME}
-  PRIVATE
-  "${JSONAPI_GENERATOR_OUTPUT_DIR}"
-)
-
 find_package(restbed REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE restbed::restbed)
 

--- a/src/jsonapi/CMakeLists.txt
+++ b/src/jsonapi/CMakeLists.txt
@@ -1,0 +1,66 @@
+# ------------------------------------------------------------------------ *\
+# src/jsonapi/CMakeLists.txt
+# This file is part of libRetroShare.
+#
+# Copyright (C) 2026      David Bears <dbear4q@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ------------------------------------------------------------------------ */
+
+find_package(Doxygen REQUIRED)
+find_package(Python3 REQUIRED)
+
+set(
+  JSONAPI_GENERATOR_EXECUTABLE
+  "${CMAKE_CURRENT_SOURCE_DIR}/jsonapi-generator.py"
+)
+
+get_target_property(RS_PUBLIC_HEADERS ${PROJECT_NAME} HEADER_SET)
+
+configure_file(
+  "jsonapi-generator-doxygen.conf.in"
+  "jsonapi-generator-doxygen.conf"
+  @ONLY
+)
+
+add_custom_command(
+  OUTPUT "jsonapi-includes.inl" "jsonapi-wrappers.inl"
+  COMMAND ${DOXYGEN_EXECUTABLE} "jsonapi-generator-doxygen.conf"
+  COMMAND ${Python3_EXECUTABLE} ${JSONAPI_GENERATOR_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+  MAIN_DEPENDENCY "${JSONAPI_GENERATOR_EXECUTABLE}"
+  DEPENDS "jsonapi-generator-doxygen.conf" ${RS_PUBLIC_HEADERS}
+)
+add_custom_target(jsonapi_headers SOURCES
+  "${CMAKE_CURRENT_BINARY_DIR}/jsonapi-includes.inl"
+  "${CMAKE_CURRENT_BINARY_DIR}/jsonapi-wrappers.inl"
+)
+add_dependencies(${PROJECT_NAME} jsonapi_headers)
+
+target_sources(${PROJECT_NAME}
+  PRIVATE FILE_SET private_HEADERS TYPE HEADERS
+  FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/jsonapi-includes.inl"
+  "${CMAKE_CURRENT_BINARY_DIR}/jsonapi-wrappers.inl"
+)
+
+target_include_directories(${PROJECT_NAME}
+  PRIVATE
+  "${JSONAPI_GENERATOR_OUTPUT_DIR}"
+)
+
+find_package(restbed REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE restbed::restbed)
+
+target_compile_definitions(${PROJECT_NAME} PUBLIC RS_JSONAPI)

--- a/src/jsonapi/jsonapi-generator-doxygen.conf.in
+++ b/src/jsonapi/jsonapi-generator-doxygen.conf.in
@@ -67,7 +67,7 @@ HIDE_UNDOC_CLASSES     = NO
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/src/
+INPUT                  = @PROJECT_SOURCE_DIR@/src/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/src/jsonapi/jsonapi-generator-doxygen.conf.in
+++ b/src/jsonapi/jsonapi-generator-doxygen.conf.in
@@ -67,7 +67,7 @@ HIDE_UNDOC_CLASSES     = NO
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-#INPUT                  =
+INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/src/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -150,7 +150,10 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = \
+  @CMAKE_CURRENT_SOURCE_DIR@/src/tests \
+  @CMAKE_CURRENT_SOURCE_DIR@/src/unused \
+  @CMAKE_CURRENT_SOURCE_DIR@/src/unfinished \
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -227,4 +230,3 @@ MACRO_EXPANSION        = NO
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 EXPAND_ONLY_PREDEF     = NO
-

--- a/src/jsonapi/jsonapi.cpp
+++ b/src/jsonapi/jsonapi.cpp
@@ -44,7 +44,7 @@
 #include "retroshare/rsversion.h"
 
 // Generated at compile time
-#include "jsonapi-includes.inl"
+#include "jsonapi/jsonapi-includes.inl"
 
 /*extern*/ RsJsonApi* rsJsonApi = nullptr;
 
@@ -538,7 +538,7 @@ JsonApiServer::JsonApiServer(): configMutex("JsonApiServer config"),
 	}, true);
 
 // Generated at compile time
-#include "jsonapi-wrappers.inl"
+#include "jsonapi/jsonapi-wrappers.inl"
 }
 
 void JsonApiServer::registerHandler(

--- a/src/rsserver/rsinit.cc
+++ b/src/rsserver/rsinit.cc
@@ -302,11 +302,7 @@ bool doPortRestrictions = false;
  */
 const char*
 RsInit::libRetroShareVersion() {
-	return
-    RS_PRIVATE_STRINGIFY(LIBRS_MAJOR_VERSION) "."
-    RS_PRIVATE_STRINGIFY(LIBRS_MINOR_VERSION) "."
-    RS_PRIVATE_STRINGIFY(LIBRS_MINI_VERSION)
-    RS_PRIVATE_STRINGIFY(LIBRS_EXTRA_VERSION);
+	return RS_PRIVATE_STRINGIFY(LIBRS_FULL_VERSION);
 }
 
 /********

--- a/src/rsserver/rsinit.cc
+++ b/src/rsserver/rsinit.cc
@@ -48,7 +48,6 @@
 #include "retroshare/rsiface.h"
 #include "retroshare/rsversion.h"
 #include "plugins/pluginmanager.h"
-#include "retroshare/rsversion.h"
 #include "rsserver/rsloginhandler.h"
 #ifdef RS_WEBUI
 #include "jsonapi/p3webui.h"

--- a/src/rsserver/rsinit.cc
+++ b/src/rsserver/rsinit.cc
@@ -46,6 +46,7 @@
 #include "retroshare/rsmail.h"
 #include "retroshare/rstor.h"
 #include "retroshare/rsiface.h"
+#include "retroshare/rsversion.h"
 #include "plugins/pluginmanager.h"
 #include "retroshare/rsversion.h"
 #include "rsserver/rsloginhandler.h"
@@ -300,13 +301,13 @@ bool doPortRestrictions = false;
  * @brief Returns the specific version of the libretroshare engine.
  * This version is retrieved from the git submodule hash during compilation.
  */
-const char* RsInit::libRetroShareVersion()
-{
-#ifdef RS_LIB_VERSION_HASH
-    return RS_LIB_VERSION_HASH;
-#else
-    return "[version not available]";
-#endif
+const char*
+RsInit::libRetroShareVersion() {
+	return
+    RS_PRIVATE_STRINGIFY(LIBRS_MAJOR_VERSION) "."
+    RS_PRIVATE_STRINGIFY(LIBRS_MINOR_VERSION) "."
+    RS_PRIVATE_STRINGIFY(LIBRS_MINI_VERSION)
+    RS_PRIVATE_STRINGIFY(LIBRS_EXTRA_VERSION);
 }
 
 /********
@@ -659,8 +660,8 @@ bool RsInit::LoadCertificates(bool autoLoginNT,LoadCertificateStatus& error_code
         error_code = ERR_NO_ACCOUNT_SELECTED;
         return false;
 	}
-		
-	
+
+
 	if (RsAccounts::AccountPathCertFile() == "")
 	{
 	  std::cerr << "RetroShare needs a certificate" << std::endl;
@@ -675,7 +676,7 @@ bool RsInit::LoadCertificates(bool autoLoginNT,LoadCertificateStatus& error_code
 	}
 
 	//check if password is already in memory
-	
+
 	if(rsInitConfig->passwd == "") {
 		if (RsLoginHandler::getSSLPassword(preferredId,true,rsInitConfig->passwd) == false) {
 #ifdef DEBUG_RSINIT
@@ -722,7 +723,7 @@ bool RsInit::LoadCertificates(bool autoLoginNT,LoadCertificateStatus& error_code
 	// ideally gxs should have its own password
 	rsInitConfig->gxs_passwd = rsInitConfig->passwd;
 	rsInitConfig->passwd = "";
-	
+
 	RsAccounts::storeSelectedAccount();
     return true;
 }
@@ -758,7 +759,7 @@ bool RsInit::isWindowsXP()
     return false;
 #endif
 }
-	
+
 bool RsInit::getStartMinimised()
 {
 	return rsInitConfig->startMinimised;
@@ -803,7 +804,7 @@ void RsInit::SetHiddenLocation(const std::string& hiddenaddress, uint16_t port, 
 #include "retroshare/rsiface.h"
 #include "retroshare/rsturtle.h"
 
-/* global variable now points straight to 
+/* global variable now points straight to
  * ft/ code so variable defined here.
  */
 
@@ -882,10 +883,10 @@ RsGRouter *rsGRouter = NULL ;
 #include "pqi/p3peermgr.h"
 #include "pqi/p3linkmgr.h"
 #include "pqi/p3netmgr.h"
-	
+
 #include "tcponudp/tou.h"
 #include "tcponudp/rsudpstack.h"
-	
+
 #ifdef RS_USE_BITDHT
 #include "dht/p3bitdht.h"
 #ifdef RS_USE_DHT_STUNNER
@@ -1338,9 +1339,9 @@ int RsServer::StartupRetroShare()
 	mPluginsManager->loadPlugins(plugins_directories) ;
 
 	// Also load some plugins explicitly. This is helpful for
-	// - developping plugins 
+	// - developping plugins
 	//
-	std::vector<RsPlugin *> programatically_inserted_plugins ;		
+	std::vector<RsPlugin *> programatically_inserted_plugins ;
 
 	// Push your own plugins into this list, before the call:
 	//
@@ -1421,24 +1422,24 @@ int RsServer::StartupRetroShare()
         // create GXS Circle service
         RsGxsNetService* gxscircles_ns = new RsGxsNetService(
                         RS_SERVICE_GXS_TYPE_GXSCIRCLE, gxscircles_ds, nxsMgr,
-                        mGxsCircles, mGxsCircles->getServiceInfo(), 
+                        mGxsCircles, mGxsCircles->getServiceInfo(),
 			mReputations, mGxsCircles,mGxsIdService,
 			pgpAuxUtils);
 
 		mGxsCircles->setNetworkExchangeService(gxscircles_ns) ;
-    
+
         /**** Posted GXS service ****/
 
         RsGeneralDataService* posted_ds = new RsDataService(currGxsDir + "/", "posted_db",
-                        RS_SERVICE_GXS_TYPE_POSTED, 
+                        RS_SERVICE_GXS_TYPE_POSTED,
 			NULL, rsInitConfig->gxs_passwd);
 
         p3Posted *mPosted = new p3Posted(posted_ds, NULL, mGxsIdService);
 
         // create GXS photo service
         RsGxsNetService* posted_ns = new RsGxsNetService(
-                        RS_SERVICE_GXS_TYPE_POSTED, posted_ds, nxsMgr, 
-			mPosted, mPosted->getServiceInfo(), 
+                        RS_SERVICE_GXS_TYPE_POSTED, posted_ds, nxsMgr,
+			mPosted, mPosted->getServiceInfo(),
 			mReputations, mGxsCircles,mGxsIdService,
 			pgpAuxUtils);
 
@@ -1534,8 +1535,8 @@ int RsServer::StartupRetroShare()
 
         // create GXS photo service
         RsGxsNetService* photo_ns = new RsGxsNetService(
-                        RS_SERVICE_GXS_TYPE_PHOTO, photo_ds, nxsMgr, 
-			mPhoto, mPhoto->getServiceInfo(), 
+                        RS_SERVICE_GXS_TYPE_PHOTO, photo_ds, nxsMgr,
+			mPhoto, mPhoto->getServiceInfo(),
 			mReputations, mGxsCircles,mGxsIdService,
 			pgpAuxUtils);
 
@@ -1551,8 +1552,8 @@ int RsServer::StartupRetroShare()
 
         // create GXS photo service
         RsGxsNetService* wire_ns = new RsGxsNetService(
-                        RS_SERVICE_GXS_TYPE_WIRE, wire_ds, nxsMgr, 
-			mWire, mWire->getServiceInfo(), 
+                        RS_SERVICE_GXS_TYPE_WIRE, wire_ds, nxsMgr,
+			mWire, mWire->getServiceInfo(),
 			mReputations, mGxsCircles,mGxsIdService,
 			pgpAuxUtils);
 
@@ -1690,7 +1691,7 @@ int RsServer::StartupRetroShare()
 	interfaces.mGxsTunnels = mGxsTunnels;
     interfaces.mReputations     = mReputations;
     interfaces.mPosted          = mPosted;
-    
+
 	mPluginsManager->setInterfaces(interfaces);
 
 	// now add plugin objects inside the loop:
@@ -1741,7 +1742,7 @@ int RsServer::StartupRetroShare()
 		rsBanList = NULL ;
 
 	p3BandwidthControl *mBwCtrl = new p3BandwidthControl(pqih);
-	pqih -> addService(mBwCtrl, true); 
+	pqih -> addService(mBwCtrl, true);
 
 #ifdef SERVICES_DSDV
 	p3Dsdv *mDsdv = new p3Dsdv(serviceCtrl);
@@ -1889,7 +1890,7 @@ int RsServer::StartupRetroShare()
 		sockaddr_storage_clear(laddr);
 
 		struct sockaddr_in *lap = (struct sockaddr_in *) &laddr;
-		
+
 		lap->sin_family = AF_INET;
 		lap->sin_port = htons(rsInitConfig->port);
 

--- a/src/util/rsnet_ss.cc
+++ b/src/util/rsnet_ss.cc
@@ -29,7 +29,7 @@
 #include <cstdlib>
 
 #ifdef WINDOWS_SYS
-#	include <Winsock2.h>
+#	include <winsock2.h>
 /** Provides Linux like accessor for in6_addr.s6_addr16 for Windows.
  * Yet Windows doesn't provide 32 bits accessors so there is no way to use
  * in6_addr.s6_addr32 crossplatform.
@@ -1033,7 +1033,7 @@ bool sockaddr_storage_ipv4_lessthan(const struct sockaddr_storage &addr, const s
 	const struct sockaddr_in *ptr1 = to_const_ipv4_ptr(addr);
 	const struct sockaddr_in *ptr2 = to_const_ipv4_ptr(addr2);
 
-	if (ptr1->sin_addr.s_addr == ptr2->sin_addr.s_addr) 
+	if (ptr1->sin_addr.s_addr == ptr2->sin_addr.s_addr)
 	{
 		return	ptr1->sin_port < ptr2->sin_port;
 	}


### PR DESCRIPTION
- improves version detection with GetGitRevisionDecription module
- moves dependency management implementation details to the superproject (cleans up the FetchContent mess that existed before)
- divorces creating the library target and adding sources
- uses source/header file sets
- moves all json api generator stuff to the src/jsonapi subdirectory
- uses configure_file to configure the jsonapi doxygen file
- uses install components intead of the RS_LIBRETROSHARE_STANDALONE_INSTALL cache variable
- fixes the install destination paths (they should be relative to the install prefix--not absolute)

As it stands, this requires a pretty recent version of CMake because I use the SOURCES file set type. I can work on supporting older versions of CMake, but for now I'd like some feedback on what I have.

This PR should be paired with RetroShare/RetroShare#3288 .