### PR TITLE
Added API for getBoardPostSummaries

### DIFF
--- a/src/retroshare/rsposted.h
+++ b/src/retroshare/rsposted.h
@@ -233,6 +233,17 @@ public:
 	        std::vector<RsGxsVote>& votes ) = 0;
 
 	/**
+	 * @brief Get lightweight summaries for top-level posts in a board.
+	 * @jsonapi{development}
+	 * @param[in] boardId id of the board of which post summaries are requested
+	 * @param[out] summaries storage for post metadata, excluding comments and votes
+	 * @return false if something failed, true otherwise
+	 */
+	virtual bool getBoardPostSummaries(
+	        const RsGxsGroupId& boardId,
+	        std::vector<RsMsgMetaData>& summaries ) = 0;
+
+	/**
 	 * @brief Edit board details.
 	 * @jsonapi{development}
 	 * @param[in] board Board data (name, description...) with modifications

--- a/src/services/p3posted.cc
+++ b/src/services/p3posted.cc
@@ -418,6 +418,28 @@ bool p3Posted::getBoardContent( const RsGxsGroupId& groupId,
 	return getPostData(token, posts, comments, votes);
 }
 
+bool p3Posted::getBoardPostSummaries(
+        const RsGxsGroupId& groupId,
+        std::vector<RsMsgMetaData>& summaries )
+{
+	uint32_t token;
+	RsTokReqOptions opts;
+	opts.mReqType = GXS_REQUEST_TYPE_MSG_META;
+
+	if( !requestMsgInfo(token, opts, std::list<RsGxsGroupId>({groupId})) ||
+	        waitToken(token, std::chrono::seconds(5)) != RsTokenService::COMPLETE )
+		return false;
+
+	GxsMsgMetaMap metaMap;
+	if( !RsGenExchange::getMsgMeta(token, metaMap) ) return false;
+
+	summaries.clear();
+	for( const auto& meta : metaMap[groupId] )
+		if( meta.mParentId.isNull() ) summaries.push_back(meta);
+
+	return true;
+}
+
 bool p3Posted::getBoardsSummaries(std::list<RsGroupMetaData>& boards )
 {
 	uint32_t token;

--- a/src/services/p3posted.h
+++ b/src/services/p3posted.h
@@ -67,6 +67,10 @@ virtual void receiveHelperChanges(std::vector<RsGxsNotify*>& changes)
 	                     std::vector<RsGxsComment>& comments,
 	                     std::vector<RsGxsVote>& votes ) override;
 
+	bool getBoardPostSummaries(
+	        const RsGxsGroupId& groupId,
+	        std::vector<RsMsgMetaData>& summaries ) override;
+
 	bool getBoardsSummaries(std::list<RsGroupMetaData>& groupInfo) override;
 
     bool subscribeToBoard( const RsGxsGroupId& boardId, bool subscribe ) override;


### PR DESCRIPTION
is required to load boards post on webui faster
webui on channels is faster, it using the getContentSummaries

chatgpt says (5.6)
> Without the libretroshare addition, WebUI only has:
> 
> - getBoardAllContent: returns every post, comment, vote, and image in one large response.
> - getBoardContent: returns selected items, but requires message IDs that WebUI does not yet know.
> 
> So WebUI cannot request only the newest 25 posts without first receiving their IDs. It can improve the experience with loading indicators, caching, or prefetching, but the initial large download would still take 20–30 seconds.
> The small getBoardPostSummaries() core API is necessary to make the first page genuinely load faster.