### PR TITLE
Stop the JSON API before plugins delete their resource providers

### DIFF
--- a/src/rsserver/p3face-config.cc
+++ b/src/rsserver/p3face-config.cc
@@ -84,6 +84,21 @@ void RsServer::rsGlobalShutDown()
 	bool wasReady = coreReady;
 	coreReady = false;
 
+#ifdef RS_JSONAPI
+	/* Stop the JSON API before anything else. Plugins delete their
+	 * JsonApiResourceProvider in stopPlugins() below, while the restbed service
+	 * still holds the resources that provider handed out -- their handlers
+	 * capture it, so serving a request in that window dereferences freed
+	 * memory. The window is not small: everything between stopPlugins() and the
+	 * end of this function can take tens of seconds, and a web interface polls
+	 * throughout. Stopping first also keeps an API client from touching the
+	 * configuration after ConfigFinalSave().
+	 *
+	 * Not inside the wasReady branch: retroshare-service and Android start the
+	 * JSON API before login, so a shutdown from that state must stop it too. */
+	if(rsJsonApi) rsJsonApi->fullstop();
+#endif
+
 	if(wasReady)
 	{
 		/* Close the incoming-connection listener FIRST, before anything else.
@@ -122,10 +137,6 @@ void RsServer::rsGlobalShutDown()
 	 * Must run after fullstop() so the RsServer tick thread is no longer
 	 * iterating the peer list concurrently. */
 	if(pqih) pqih->fullstopAllThreads();
-
-#ifdef RS_JSONAPI
-	if(rsJsonApi) rsJsonApi->fullstop();
-#endif
 
 	AuthPGP::exit();
 


### PR DESCRIPTION
`RsServer::rsGlobalShutDown()` stops the JSON API almost last, after `stopPlugins()`.

A plugin that registered a `JsonApiResourceProvider` deletes it in its `stop()`, but the running restbed service still holds the `restbed::Resource` objects that provider returned, and their handlers capture it — `JsonApiServer::run()` publishes them once at thread start and the service keeps them for its whole lifetime. Any request served between `stopPlugins()` and the `fullstop()` at the end of the function therefore dereferences freed memory.

The window is not theoretical. Everything in between — UPnP teardown, the auto-proxy shutdown, all registered service threads, the `RsServer` tick thread and the per-peer streamers — can take tens of seconds, and a web interface polls throughout.

This moves the `fullstop()` to the top of the function. Two details worth noting:

- it also keeps an API client from touching the configuration after `ConfigFinalSave()`, which runs a couple of lines below;
- it stays **outside** the `wasReady` branch, because retroshare-service and Android start the JSON API before login, so a shutdown from that state has to stop it too. That is why the call cannot simply be hoisted into the existing block.

No plugin in the tree registers a resource provider today, so nothing is currently affected. It becomes reachable with RetroShare/libretroshare#364 and RetroShare/RetroShare#3289, which give plugins access to the JSON API — and without this change, a plugin has to restart the whole JSON API from its `stop()` just to make deleting its own provider safe, which costs a `RESTART_BURST_PROTECTION` wait and brings the server back up in the middle of the core teardown.

Sending it separately since it stands on its own and fixes a latent defect for any future provider-registering plugin.

Not build-tested yet.