### PR TITLE
CMake CI: build libretroshare on Linux, Windows and macOS

### DIFF
--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -50,7 +50,7 @@ jobs:
         brew install
         cmake ninja pkg-config
         openssl@3 botan@2 sqlcipher miniupnpc json-c
-        bzip2 zlib doxygen gnu-sed
+        bzip2 zlib doxygen gnu-sed rapidjson
 
     # The restbed patch step of CMakeLists.txt runs `sed -i -e ...`, which is
     # GNU syntax: BSD sed reads the argument after -i as a backup suffix and

--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -50,10 +50,17 @@ jobs:
         brew install
         cmake ninja pkg-config
         openssl@3 botan@2 sqlcipher miniupnpc json-c
-        bzip2 zlib doxygen
+        bzip2 zlib doxygen gnu-sed
 
+    # The restbed patch step of CMakeLists.txt runs `sed -i -e ...`, which is
+    # GNU syntax: BSD sed reads the argument after -i as a backup suffix and
+    # fails with "sed: -e: No such file or directory". The super-project never
+    # hits it -- it has restbed as a submodule and takes the add_subdirectory
+    # branch instead of FetchContent -- so this only shows up in the standalone
+    # build. Put GNU sed first in PATH rather than patch the CMakeLists.
     - name: CMake configure
       run: |
+        export PATH="$(brew --prefix gnu-sed)/libexec/gnubin:$PATH"
         HB="$(brew --prefix)"
         IFLAGS="-I$HB/include"; for d in "$HB"/opt/*/include; do IFLAGS="$IFLAGS -I$d"; done
         LFLAGS="-L$HB/lib";     for d in "$HB"/opt/*/lib;     do LFLAGS="$LFLAGS -L$d"; done

--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -1,0 +1,75 @@
+# macOS CMake CI for libretroshare on its own.
+#
+# Same standalone build as the Ubuntu and Windows jobs: libretroshare has its
+# own top level CMakeLists.txt and pulls rnp, OpenPGP-SDK, BitDHT, rapidjson,
+# restbed and udp-discovery-cpp through FetchContent, so no super-project and no
+# submodules are involved. Only the Homebrew formulae below are installed, and
+# none of the GUI ones the super-project needs -- this repository builds no
+# interface.
+#
+# Homebrew keeps most of these keg-only, so their headers and libraries are not
+# on the default search paths. Same treatment as the super-project's macOS job:
+# harvest every opt/* include and lib directory into the compiler and linker
+# flags, and expose the prefixes to find_package() through CMAKE_PREFIX_PATH.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: macOS CMake C/C++ CI
+
+on:
+  push:
+    paths-ignore:
+    - '**/*.md'
+  pull_request:
+    paths-ignore:
+    - '**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: macOS / CMake
+    runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Install Homebrew dependencies
+      run: >
+        brew install
+        cmake ninja pkg-config
+        openssl@3 sqlcipher miniupnpc json-c
+        bzip2 zlib doxygen
+
+    - name: CMake configure
+      run: |
+        HB="$(brew --prefix)"
+        IFLAGS="-I$HB/include"; for d in "$HB"/opt/*/include; do IFLAGS="$IFLAGS -I$d"; done
+        LFLAGS="-L$HB/lib";     for d in "$HB"/opt/*/lib;     do LFLAGS="$LFLAGS -L$d"; done
+        PREFIX="$HB";           for d in "$HB"/opt/*;          do PREFIX="$PREFIX;$d"; done
+        cmake -G Ninja -B Build-cmake -S . \
+          -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_PREFIX_PATH="$PREFIX" \
+          -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" \
+          -DRS_RNPLIB=ON -DRS_JSON_API=ON -DRS_WEBUI=OFF \
+          -DRS_SQLCIPHER=ON -DRS_BITDHT=ON \
+          -DRS_BRODCAST_DISCOVERY=ON -DRS_MINIUPNPC=ON \
+          -DRS_FORUM_DEEP_INDEX=OFF \
+          -DCMAKE_C_FLAGS="$IFLAGS" -DCMAKE_CXX_FLAGS="$IFLAGS" \
+          -DCMAKE_EXE_LINKER_FLAGS="$LFLAGS" \
+          -DCMAKE_SHARED_LINKER_FLAGS="$LFLAGS" \
+          -DCMAKE_MODULE_LINKER_FLAGS="$LFLAGS"
+
+    - name: CMake build
+      run: cmake --build Build-cmake -j$(sysctl -n hw.ncpu)

--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -49,7 +49,7 @@ jobs:
       run: >
         brew install
         cmake ninja pkg-config
-        openssl@3 sqlcipher miniupnpc json-c
+        openssl@3 botan@2 sqlcipher miniupnpc json-c
         bzip2 zlib doxygen
 
     - name: CMake configure

--- a/.github/workflows/ubuntu-cmake.yml
+++ b/.github/workflows/ubuntu-cmake.yml
@@ -52,7 +52,7 @@ jobs:
         sudo apt-get update &&
         sudo apt-get install -y
         build-essential g++ cmake ninja-build pkg-config git
-        libssl-dev zlib1g-dev libbz2-dev libjson-c-dev libbotan-2-dev
+        libssl-dev zlib1g-dev libbz2-dev libjson-c-dev libbotan-2-dev rapidjson-dev
         libsqlcipher-dev libminiupnpc-dev
         doxygen python3
 

--- a/.github/workflows/ubuntu-cmake.yml
+++ b/.github/workflows/ubuntu-cmake.yml
@@ -1,0 +1,70 @@
+# Ubuntu CMake CI for libretroshare on its own.
+#
+# libretroshare has a top level CMakeLists.txt of its own -- project(retroshare)
+# -- and pulls what it needs through FetchContent: rnp, OpenPGP-SDK, BitDHT,
+# rapidjson, restbed, udp-discovery-cpp. So it configures and builds without the
+# RetroShare super-project, without submodules and without any graft. Only the
+# system libraries below have to be installed.
+#
+# Options mirror the Linux CMake job of the super-project, minus everything that
+# does not exist in this repository: no GUI, no service, no friendserver, no
+# plugins. Everything else is left at the value a normal build uses, so the CI
+# compiles what people actually ship -- RS_MINIUPNPC in particular defaults to
+# ON, and switching it off to save one package would leave that code untested.
+#
+# Two deliberate departures: RS_JSON_API is OFF by default here and is turned
+# on, since it is the part of the tree most exposed to breakage and the reason
+# restbed is fetched at all; RS_WEBUI stays off, as it only serves files the
+# super-project provides.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Ubuntu CMake C/C++ CI
+
+on:
+  push:
+    paths-ignore:
+    - '**/*.md'
+  pull_request:
+    paths-ignore:
+    - '**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Ubuntu / CMake
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Install dependencies
+      run: >
+        sudo apt-get update &&
+        sudo apt-get install -y
+        build-essential g++ cmake ninja-build pkg-config git
+        libssl-dev zlib1g-dev libbz2-dev libjson-c-dev
+        libsqlcipher-dev libminiupnpc-dev
+        doxygen python3
+
+    - name: CMake configure
+      run: >
+        cmake -G Ninja -B Build-cmake -S .
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        -DCMAKE_BUILD_TYPE=Release
+        -DRS_RNPLIB=ON -DRS_JSON_API=ON -DRS_WEBUI=OFF
+        -DRS_SQLCIPHER=ON -DRS_BITDHT=ON
+        -DRS_BRODCAST_DISCOVERY=ON -DRS_MINIUPNPC=ON
+        -DRS_FORUM_DEEP_INDEX=OFF
+
+    - name: CMake build
+      run: cmake --build Build-cmake -j$(nproc)

--- a/.github/workflows/ubuntu-cmake.yml
+++ b/.github/workflows/ubuntu-cmake.yml
@@ -52,7 +52,7 @@ jobs:
         sudo apt-get update &&
         sudo apt-get install -y
         build-essential g++ cmake ninja-build pkg-config git
-        libssl-dev zlib1g-dev libbz2-dev libjson-c-dev
+        libssl-dev zlib1g-dev libbz2-dev libjson-c-dev libbotan-2-dev
         libsqlcipher-dev libminiupnpc-dev
         doxygen python3
 

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -73,6 +73,10 @@ jobs:
       # headers that need C++11. This launcher rewrites that one flag and
       # forwards everything else untouched, so nothing else in the build is
       # affected and CMakeLists.txt stays as it is.
+      #
+      # Invoked as "bash;<script>": ninja calls the launcher through
+      # CreateProcess, which cannot run a .sh -- it reports "%1 is not a valid
+      # Win32 application" -- so bash has to be named explicitly.
       - name: Compiler launcher rewriting -std=gnu++98
         run: |
           cat > "$RUNNER_TEMP/cxx-launcher.sh" <<'SH'
@@ -91,7 +95,7 @@ jobs:
       - name: CMake configure
         run: >
           cmake -G Ninja -B Build-cmake -S .
-          -DCMAKE_CXX_COMPILER_LAUNCHER="$RUNNER_TEMP/cxx-launcher.sh"
+          "-DCMAKE_CXX_COMPILER_LAUNCHER=bash;$RUNNER_TEMP/cxx-launcher.sh"
           -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           -DCMAKE_BUILD_TYPE=Release
           -DRS_RNPLIB=ON -DRS_JSON_API=ON -DRS_WEBUI=OFF

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -1,0 +1,82 @@
+# Windows (MSYS2 / UCRT64) CMake CI for libretroshare on its own.
+#
+# Same standalone build as ubuntu-cmake.yml: libretroshare has its own top level
+# CMakeLists.txt and pulls rnp, OpenPGP-SDK, BitDHT, rapidjson, restbed and
+# udp-discovery-cpp through FetchContent, so no super-project and no submodules
+# are involved. Only the MSYS2 packages below are installed.
+#
+# Windows earns its own job rather than a matrix entry: it is where portability
+# breaks first, its dependencies come from pacman rather than apt, and it needs
+# the two -include flags below, which the super-project's Windows job also
+# carries -- librnp uses strlen and the fixed width integer types without
+# including <cstring> and <cstdint>, which this toolchain refuses.
+#
+# No Qt packages: this repository builds no GUI.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Windows UCRT64 CMake C/C++ CI
+
+on:
+  push:
+    paths-ignore:
+    - '**/*.md'
+  pull_request:
+    paths-ignore:
+    - '**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Windows UCRT64 / CMake
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup MSYS2 (UCRT64)
+        uses: msys2/setup-msys2@40677d36a502eb2cf0fb808cc9dec31bf6152638 # v2.28.0
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            base-devel
+            git
+            mingw-w64-ucrt-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-python
+            mingw-w64-ucrt-x86_64-doxygen
+            mingw-w64-ucrt-x86_64-openssl
+            mingw-w64-ucrt-x86_64-sqlcipher
+            mingw-w64-ucrt-x86_64-miniupnpc
+            mingw-w64-ucrt-x86_64-json-c
+            mingw-w64-ucrt-x86_64-bzip2
+            mingw-w64-ucrt-x86_64-zlib
+
+      - name: CMake configure
+        run: >
+          cmake -G Ninja -B Build-cmake -S .
+          -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          -DCMAKE_BUILD_TYPE=Release
+          -DRS_RNPLIB=ON -DRS_JSON_API=ON -DRS_WEBUI=OFF
+          -DRS_SQLCIPHER=ON -DRS_BITDHT=ON
+          -DRS_BRODCAST_DISCOVERY=ON -DRS_MINIUPNPC=ON
+          -DRS_FORUM_DEEP_INDEX=OFF
+          -DCMAKE_C_FLAGS="-include string.h -include stdint.h"
+          -DCMAKE_CXX_FLAGS="-include cstring -include cstdint -Wno-template-body"
+
+      - name: CMake build
+        run: cmake --build Build-cmake -j3

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -61,6 +61,7 @@ jobs:
             mingw-w64-ucrt-x86_64-doxygen
             mingw-w64-ucrt-x86_64-openssl
             mingw-w64-ucrt-x86_64-libbotan
+            mingw-w64-ucrt-x86_64-rapidjson
             mingw-w64-ucrt-x86_64-sqlcipher
             mingw-w64-ucrt-x86_64-miniupnpc
             mingw-w64-ucrt-x86_64-json-c

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -60,6 +60,7 @@ jobs:
             mingw-w64-ucrt-x86_64-python
             mingw-w64-ucrt-x86_64-doxygen
             mingw-w64-ucrt-x86_64-openssl
+            mingw-w64-ucrt-x86_64-libbotan
             mingw-w64-ucrt-x86_64-sqlcipher
             mingw-w64-ucrt-x86_64-miniupnpc
             mingw-w64-ucrt-x86_64-json-c

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -93,17 +93,23 @@ jobs:
           chmod +x "$RUNNER_TEMP/cxx-launcher.sh"
 
       - name: CMake configure
-        run: >
-          cmake -G Ninja -B Build-cmake -S .
-          "-DCMAKE_CXX_COMPILER_LAUNCHER=bash;$RUNNER_TEMP/cxx-launcher.sh"
-          -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-          -DCMAKE_BUILD_TYPE=Release
-          -DRS_RNPLIB=ON -DRS_JSON_API=ON -DRS_WEBUI=OFF
-          -DRS_SQLCIPHER=ON -DRS_BITDHT=ON
-          -DRS_BRODCAST_DISCOVERY=ON -DRS_MINIUPNPC=ON
-          -DRS_FORUM_DEEP_INDEX=OFF
-          -DCMAKE_C_FLAGS="-include string.h -include stdint.h"
-          -DCMAKE_CXX_FLAGS="-include cstring -include cstdint -Wno-template-body"
+        run: |
+          # Plain "bash" would be resolved by CreateProcess to Windows' own
+          # C:\Windows\System32\bash.exe -- the WSL stub, which answers
+          # "Windows Subsystem for Linux has no installed distributions".
+          # Name the MSYS2 one, in a path CMake and ninja can both use.
+          BASH_EXE="$(cygpath -m "$(command -v bash)")"
+          LAUNCHER="$(cygpath -m "$RUNNER_TEMP/cxx-launcher.sh")"
+          cmake -G Ninja -B Build-cmake -S . \
+            "-DCMAKE_CXX_COMPILER_LAUNCHER=$BASH_EXE;$LAUNCHER" \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DRS_RNPLIB=ON -DRS_JSON_API=ON -DRS_WEBUI=OFF \
+            -DRS_SQLCIPHER=ON -DRS_BITDHT=ON \
+            -DRS_BRODCAST_DISCOVERY=ON -DRS_MINIUPNPC=ON \
+            -DRS_FORUM_DEEP_INDEX=OFF \
+            -DCMAKE_C_FLAGS="-include string.h -include stdint.h" \
+            -DCMAKE_CXX_FLAGS="-include cstring -include cstdint -Wno-template-body"
 
       - name: CMake build
         run: cmake --build Build-cmake -j3

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -68,17 +68,36 @@ jobs:
             mingw-w64-ucrt-x86_64-bzip2
             mingw-w64-ucrt-x86_64-zlib
 
+      # udp-discovery-cpp sets CXX_STANDARD 98 as a target property, which no
+      # command line option can override, and its own sources then include
+      # headers that need C++11. This launcher rewrites that one flag and
+      # forwards everything else untouched, so nothing else in the build is
+      # affected and CMakeLists.txt stays as it is.
+      - name: Compiler launcher rewriting -std=gnu++98
+        run: |
+          cat > "$RUNNER_TEMP/cxx-launcher.sh" <<'SH'
+          #!/usr/bin/env bash
+          args=()
+          for a in "$@"; do
+            case "$a" in
+              -std=gnu++98|-std=c++98) a="-std=gnu++17" ;;
+            esac
+            args+=("$a")
+          done
+          exec "${args[@]}"
+          SH
+          chmod +x "$RUNNER_TEMP/cxx-launcher.sh"
+
       - name: CMake configure
         run: >
           cmake -G Ninja -B Build-cmake -S .
+          -DCMAKE_CXX_COMPILER_LAUNCHER="$RUNNER_TEMP/cxx-launcher.sh"
           -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           -DCMAKE_BUILD_TYPE=Release
           -DRS_RNPLIB=ON -DRS_JSON_API=ON -DRS_WEBUI=OFF
           -DRS_SQLCIPHER=ON -DRS_BITDHT=ON
           -DRS_BRODCAST_DISCOVERY=ON -DRS_MINIUPNPC=ON
           -DRS_FORUM_DEEP_INDEX=OFF
-          -DCMAKE_CXX98_STANDARD_COMPILE_OPTION=-std=gnu++17
-          -DCMAKE_CXX98_EXTENSION_COMPILE_OPTION=-std=gnu++17
           -DCMAKE_C_FLAGS="-include string.h -include stdint.h"
           -DCMAKE_CXX_FLAGS="-include cstring -include cstdint -Wno-template-body"
 

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -11,6 +11,20 @@
 # carries -- librnp uses strlen and the fixed width integer types without
 # including <cstring> and <cstdint>, which this toolchain refuses.
 #
+# One option differs from the other two jobs, on purpose: RS_BRODCAST_DISCOVERY
+# is OFF here. It pulls udp-discovery-cpp, whose CMakeLists sets CXX_STANDARD 98
+# as a target property while its sources include headers that need C++11 -- the
+# UCRT64 toolchain refuses that combination, the older GCC on the Ubuntu runner
+# does not. Nothing outside that project's own CMakeLists can raise the standard
+# of one of its targets, and rewriting the flag through a compiler launcher made
+# the longest command lines overflow the CreateProcess limit, which cost the
+# source file at the end of them.
+#
+# It should not stay off. The fix belongs in libretroshare's CMakeLists, whose
+# FetchContent asks for GIT_TAG "origin/master" of that third party project --
+# so this build follows whatever it does today, while the super-project pins a
+# submodule at f3a3103 and never sees the problem.
+#
 # No Qt packages: this repository builds no GUI.
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
@@ -68,45 +82,14 @@ jobs:
             mingw-w64-ucrt-x86_64-bzip2
             mingw-w64-ucrt-x86_64-zlib
 
-      # udp-discovery-cpp sets CXX_STANDARD 98 as a target property, which no
-      # command line option can override, and its own sources then include
-      # headers that need C++11. This launcher rewrites that one flag and
-      # forwards everything else untouched, so nothing else in the build is
-      # affected and CMakeLists.txt stays as it is.
-      #
-      # Invoked as "bash;<script>": ninja calls the launcher through
-      # CreateProcess, which cannot run a .sh -- it reports "%1 is not a valid
-      # Win32 application" -- so bash has to be named explicitly.
-      - name: Compiler launcher rewriting -std=gnu++98
-        run: |
-          cat > "$RUNNER_TEMP/cxx-launcher.sh" <<'SH'
-          #!/usr/bin/env bash
-          args=()
-          for a in "$@"; do
-            case "$a" in
-              -std=gnu++98|-std=c++98) a="-std=gnu++17" ;;
-            esac
-            args+=("$a")
-          done
-          exec "${args[@]}"
-          SH
-          chmod +x "$RUNNER_TEMP/cxx-launcher.sh"
-
       - name: CMake configure
         run: |
-          # Plain "bash" would be resolved by CreateProcess to Windows' own
-          # C:\Windows\System32\bash.exe -- the WSL stub, which answers
-          # "Windows Subsystem for Linux has no installed distributions".
-          # Name the MSYS2 one, in a path CMake and ninja can both use.
-          BASH_EXE="$(cygpath -m "$(command -v bash)")"
-          LAUNCHER="$(cygpath -m "$RUNNER_TEMP/cxx-launcher.sh")"
           cmake -G Ninja -B Build-cmake -S . \
-            "-DCMAKE_CXX_COMPILER_LAUNCHER=$BASH_EXE;$LAUNCHER" \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_BUILD_TYPE=Release \
             -DRS_RNPLIB=ON -DRS_JSON_API=ON -DRS_WEBUI=OFF \
             -DRS_SQLCIPHER=ON -DRS_BITDHT=ON \
-            -DRS_BRODCAST_DISCOVERY=ON -DRS_MINIUPNPC=ON \
+            -DRS_BRODCAST_DISCOVERY=OFF -DRS_MINIUPNPC=ON \
             -DRS_FORUM_DEEP_INDEX=OFF \
             -DCMAKE_C_FLAGS="-include string.h -include stdint.h" \
             -DCMAKE_CXX_FLAGS="-include cstring -include cstdint -Wno-template-body"

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -77,6 +77,8 @@ jobs:
           -DRS_SQLCIPHER=ON -DRS_BITDHT=ON
           -DRS_BRODCAST_DISCOVERY=ON -DRS_MINIUPNPC=ON
           -DRS_FORUM_DEEP_INDEX=OFF
+          -DCMAKE_CXX98_STANDARD_COMPILE_OPTION=-std=gnu++17
+          -DCMAKE_CXX98_EXTENSION_COMPILE_OPTION=-std=gnu++17
           -DCMAKE_C_FLAGS="-include string.h -include stdint.h"
           -DCMAKE_CXX_FLAGS="-include cstring -include cstdint -Wno-template-body"
 


### PR DESCRIPTION
libretroshare has no CI that compiles it. This adds three CMake jobs — Ubuntu, Windows UCRT64, macOS — all green:

https://github.com/jolavillette/libretroshare/actions?query=branch%3Aci%2Fcmake

No submodules, no super-project: the top level `CMakeLists.txt` pulls rnp, OpenPGP-SDK, BitDHT, rapidjson, restbed and udp-discovery-cpp through FetchContent, so a checkout plus the system libraries is enough. Options follow the super-project's Linux CMake job, minus what does not exist here (GUI, service, friendserver, plugins).

Nothing outside `.github/workflows/` is touched.

### Three things the standalone build hits, that the super-project never does

It always takes the `../supportlibs/...` branch of the dependency lookups, so the FetchContent branch had never run anywhere. Worked around in the workflows, but they are worth fixing in `CMakeLists.txt`:

1. **rapidjson**: `FetchContent_MakeAvailable(rapidjson)` adds no include directory, so `rapidjson/document.h` is not found. Workaround: install the system package.
2. **restbed**: the patch step runs `sed -i -e ...`, which is GNU syntax; BSD sed reads `-e` as a backup suffix. Workaround: GNU sed first in PATH on macOS.
3. **udp-discovery-cpp**: fetched at `GIT_TAG "origin/master"` — a moving third-party tip. It sets `CXX_STANDARD 98` on its target while its sources need C++11; UCRT64 refuses. Workaround: `RS_BRODCAST_DISCOVERY=OFF` on Windows only, noted in the file. Pinning a tag would fix it properly.
