### PR TITLE
build: wipe the doxygen xml dir before regenerating the jsonapi bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,10 +560,27 @@ if(RS_JSON_API)
 	)
 	file(WRITE "${JSON_API_GENERATOR_DOXYFILE}" "${DOXYFILE_CONTENT}")
 
+	# Doxygen never purges its output directory, and the generator emits one
+	# #include per *_8h.xml file it finds there. Without removing them first, the
+	# XML of a public header that has been removed or renamed survives forever and
+	# keeps being turned into an #include of a file that no longer exists.
+	# cmake -E rm does not expand wildcards, so the glob is done by a generated
+	# script run at build time.
+	set(
+		JSON_API_PURGE_XML_SCRIPT
+		"${JSON_API_GENERATOR_WORK_DIR}/purge-stale-header-xml.cmake" )
+	file(WRITE "${JSON_API_PURGE_XML_SCRIPT}"
+		"file(GLOB stale_header_xml \"${JSONAPI_GENERATOR_OUTPUT_DIR}/xml/*_8h.xml\")\n"
+		"if(stale_header_xml)\n"
+		"\tfile(REMOVE \${stale_header_xml})\n"
+		"endif()\n"
+	)
+
 	add_custom_command(
 		OUTPUT
 			"${JSONAPI_GENERATOR_OUTPUT_DIR}/jsonapi-includes.inl"
 			"${JSONAPI_GENERATOR_OUTPUT_DIR}/jsonapi-wrappers.inl"
+		COMMAND ${CMAKE_COMMAND} -P "${JSON_API_PURGE_XML_SCRIPT}"
 		COMMAND ${DOXYGEN_EXECUTABLE} ${JSON_API_GENERATOR_DOXYFILE}
 		COMMAND
 			${Python3_EXECUTABLE} ${JSONAPI_GENERATOR_EXECUTABLE}

--- a/src/libretroshare.pro
+++ b/src/libretroshare.pro
@@ -1029,9 +1029,14 @@ rs_jsonapi {
     genjsonapi.clean = $${WRAPPERS_INCL_FILE} $${WRAPPERS_REG_FILE}
     genjsonapi.CONFIG += target_predeps combine no_link
     genjsonapi.variable_out = HEADERS
+    # Doxygen never purges its output directory, and the generator emits one
+    # #include per *_8h.xml file it finds there. Without removing them first, the
+    # XML of a public header that has been removed or renamed survives forever and
+    # keeps being turned into an #include of a file that no longer exists.
     win32-g++:isEmpty(QMAKE_SH) {
         genjsonapi.commands = \
             $(CHK_DIR_EXISTS) $$shell_path($$JSONAPI_GENERATOR_OUT) $(MKDIR) $$shell_path($${JSONAPI_GENERATOR_OUT}) $$escape_expand(\\n\\t) \
+            -$(DEL_FILE) $$shell_path($${JSONAPI_GENERATOR_OUT}/xml/*_8h.xml) $$escape_expand(\\n\\t) \
             $(COPY_FILE) $$shell_path($${DOXIGEN_CONFIG_SRC}) $$shell_path($${DOXIGEN_CONFIG_OUT}) $$escape_expand(\\n\\t) \
             echo OUTPUT_DIRECTORY=$${JSONAPI_GENERATOR_OUT} >> $$shell_path($${DOXIGEN_CONFIG_OUT}) $$escape_expand(\\n\\t) \
             echo INPUT=$${DOXIGEN_INPUT_DIRECTORY} >> $$shell_path($${DOXIGEN_CONFIG_OUT}) $$escape_expand(\\n\\t) \
@@ -1039,6 +1044,7 @@ rs_jsonapi {
     } else {
         genjsonapi.commands = \
             mkdir -p $${JSONAPI_GENERATOR_OUT} && \
+            rm -f $${JSONAPI_GENERATOR_OUT}/xml/*_8h.xml && \
             cp $${DOXIGEN_CONFIG_SRC} $${DOXIGEN_CONFIG_OUT} && \
             echo OUTPUT_DIRECTORY=$${JSONAPI_GENERATOR_OUT} >> $${DOXIGEN_CONFIG_OUT} && \
             echo INPUT=$${DOXIGEN_INPUT_DIRECTORY} >> $${DOXIGEN_CONFIG_OUT} && \


### PR DESCRIPTION
A build directory that predates the removal or rename of a public header keeps failing with:

```
jsonapi-includes.inl:11:10: fatal error: retroshare/rsmsgs.h: No such file or directory
```

`rsmsgs.h` was removed by fd79225f8 ("started separating rsMsgs into rsMail and rsChats"), and grepping the sources for it finds nothing — because it is not in the sources. Doxygen never purges its `OUTPUT_DIRECTORY`, so `rsmsgs_8h.xml` is still sitting in the build tree, and both generators emit one `#include` per `*_8h.xml` file they find there, built from that XML's `<location file=...>`. The dead header is re-included on every rebuild, and `jsonapi-wrappers.inl` gets the matching dead wrappers.

`make clean` does not cure it: `genjsonapi.clean` lists only the two `.inl` files, never the `xml/` directory. The clean deletes the outputs, doxygen reruns, and the same `#include` comes back from the surviving XML. The only workaround is deleting the whole build directory, which is not something the error message suggests.

So delete the `*_8h.xml` files right before invoking doxygen, in both build systems. Only those files drive the generators (`jsonapi-generator.cpp` iterates `*8h.xml`, `jsonapi-generator.py` filters on `endswith("8h.xml")`); every other XML they open is reached through a live header's XML, which doxygen has just regenerated. This costs nothing: doxygen re-parses its whole input on every run anyway, it just stops reusing the stale header files.

`cmake -E rm` does not expand wildcards, so the CMake side does the glob in a small script generated next to the doxyfile.

Reproduced by dropping a single crafted `rsmsgs_8h.xml` into an otherwise up-to-date xml directory — the generator emits `#include "retroshare/rsmsgs.h"` again; with the deletion in place the output is clean.

Reported by Cyril on the dev chat.
