### PR TITLE
Android: skip the rnp cross-compile patch when upstream already has it

### DIFF
--- a/misc/Android/prepare-toolchain-clang.sh
+++ b/misc/Android/prepare-toolchain-clang.sh
@@ -859,8 +859,18 @@ build_librnp()
 	# 3. Add -static linking via MKF so the binary doesn't need the Android
 	#    dynamic linker which is unavailable on the host even via qemu
 	# 4. Remove quotes around FOF so CMake expands the list correctly
-	# TODO: remove when upstream patches are accepted
 	#
+	# Skip the patch when the checkout already handles the emulator on its own:
+	# rnp got this upstream (rnpgp/rnp 0a0672af, merged 2026-07-31) and
+	# LIBRNP_SOURCE_VERSION tracks origin/main, so patching on top of it
+	# prepends the emulator twice and the probe becomes
+	# "qemu-aarch64 /usr/bin/qemu-aarch64 build/findopensslfeatures", which
+	# fails with "Invalid ELF image for this architecture".
+	# TODO: drop the whole block once no supported rnp version needs it
+	#
+	grep -q CMAKE_CROSSCOMPILING_EMULATOR \
+		"${S_dir}/cmake/Modules/FindOpenSSLFeatures.cmake" ||
+	{
 	sed -i '/foreach(feature "hashes"/i\
 if(CMAKE_CROSSCOMPILING_EMULATOR)\
   set(FOF ${CMAKE_CROSSCOMPILING_EMULATOR} ${FOF})\
@@ -877,6 +887,7 @@ endif(CMAKE_CROSSCOMPILING_EMULATOR)' \
 
 	sed -i 's|COMMAND "${FOF}" "${feature}"|COMMAND ${FOF} "${feature}"|' \
 		"${S_dir}/cmake/Modules/FindOpenSSLFeatures.cmake"
+	}
 
 	rm -rf "$B_dir"; mkdir "$B_dir"
 	pushd "$B_dir" || return $?


### PR DESCRIPTION
The Android toolchain script patches rnp's `FindOpenSSLFeatures.cmake` with three `sed` calls to teach it `CMAKE_CROSSCOMPILING_EMULATOR`, with a `TODO: remove when upstream patches are accepted`.

Those patches **were** accepted: rnpgp/rnp `0a0672af` ("Fix cross-compilation with openssl backend", merged 2026-07-31), plus `69104ea4` and `3ad7f471`. And `LIBRNP_SOURCE_VERSION` defaults to `origin/main`, i.e. the tip, so the checkout already carries them. The `sed` then adds the emulator a second time:

```
set(FOF ${CMAKE_CROSSCOMPILING_EMULATOR} ${FOF})    upstream
set(FOF ${CMAKE_CROSSCOMPILING_EMULATOR} ${FOF})    added by the sed
```

so the OpenSSL feature probe is run as `qemu-aarch64 /usr/bin/qemu-aarch64 build/findopensslfeatures hashes`: qemu tries to load its own x86-64 binary as an aarch64 program and every Android build dies at configure time with

```
CMake Error at cmake/Modules/FindOpenSSLFeatures.cmake:184 (message):
  Error getting supported OpenSSL hashes: 255

  qemu-aarch64: /usr/bin/qemu-aarch64: Invalid ELF image for this architecture

Call Stack (most recent call first):
  src/lib/CMakeLists.txt:73 (include)
```

This guards the patch block on the checkout not handling the emulator itself, so both current `main` and an older pinned rnp still configure. The whole block can be dropped once no supported rnp version needs it.

Verified by replaying the two inserting `sed`s on today's upstream `FindOpenSSLFeatures.cmake` (the `FATAL_ERROR` lands exactly on line 184, as reported) and by running the guarded block against both an old and a current copy of the file: patched once on the old one, untouched on the current one.

Reported on IRC by defnax, who hit it building the AAR for rs-mobile.