### PR TITLE
Android: pin the rnp crypto backend to openssl for libretroshare too

### DIFF
--- a/misc/Android/prepare-toolchain-clang.sh
+++ b/misc/Android/prepare-toolchain-clang.sh
@@ -918,7 +918,14 @@ build_libretroshare()
 	rm -rf $B_dir
 	mkdir $B_dir || return $?
 	pushd $B_dir || return $?
+	## CRYPTO_BACKEND matters only when libretroshare CMake ends up building
+	## librnp inline, which happens when it is checked out inside the
+	## RetroShare super-project, as ../supportlibs/librnp then exists. Without
+	## it rnp defaults to botan, which the Android toolchain does not provide,
+	## and configure dies on "Could NOT find Botan". Keep it aligned with the
+	## backend build_librnp uses for the sysroot copy.
 	andro_cmake -B. -H${S_dir} \
+		-D CRYPTO_BACKEND=openssl \
 		-D RS_ANDROID=ON -D RS_WARN_DEPRECATED=OFF -D RS_WARN_LESS=ON \
 		-D RS_LIBRETROSHARE_STATIC=OFF -D RS_LIBRETROSHARE_SHARED=ON \
 		-D RS_BRODCAST_DISCOVERY=ON -D RS_EXPORT_JNI_ONLOAD=ON \


### PR DESCRIPTION
`build_librnp` builds and installs rnp into the Android sysroot with `-DCRYPTO_BACKEND=openssl`, but libretroshare's own configure can build rnp a **second** time, inline: `CMakeLists.txt` uses `add_subdirectory()` whenever `../supportlibs/librnp/CMakeLists.txt` exists, which is the case as soon as libretroshare is checked out inside the RetroShare super-project rather than standalone.

That inline build gets rnp's default backend, botan, and configure dies with

```
Could NOT find Botan (missing: BOTAN_LIBRARY BOTAN_INCLUDE_DIR)
(Required is at least version "2.14.0")
```

since the Android toolchain never builds botan.

Passing the same backend `build_librnp` uses fixes it. It is a no-op for standalone libretroshare checkouts, where `../supportlibs/librnp` does not exist and the pre-built rnp from the sysroot is picked up by `find_library()` instead — which is why CI never saw this.

Reported on IRC by defnax, who hit it building the AAR for rs-mobile from a super-project checkout.