### PR TITLE
Android: use the librnp built for the sysroot instead of rebuilding it inline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,7 +379,23 @@ if(RS_RNPLIB)
 
 	set(RNPLIB_DEVEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../supportlibs/librnp/")
 
-	if(EXISTS "${RNPLIB_DEVEL_DIR}/CMakeLists.txt")
+	## On Android prefer an already built and installed librnp, which
+	## prepare-toolchain-clang.sh puts in the sysroot before configuring us.
+	## Building it inline instead cannot work: librnp's CMake runs a freshly
+	## compiled findopensslfeatures to enumerate the OpenSSL features, and that
+	## binary is an Android executable the build host cannot run -- either not
+	## at all, or through binfmt/qemu which then fails on the missing Android
+	## dynamic linker:
+	##   qemu-aarch64: Could not open '/system/bin/linker64': No such file or
+	##   directory
+	## The inline build is only reached when libretroshare is checked out
+	## inside the RetroShare super-project, which is why building from a
+	## standalone clone has always worked.
+	if(RS_ANDROID)
+		find_library(RS_PREBUILT_RNP_LIBRARY NAMES rnp)
+	endif(RS_ANDROID)
+
+	if(NOT RS_PREBUILT_RNP_LIBRARY AND EXISTS "${RNPLIB_DEVEL_DIR}/CMakeLists.txt")
 		message(STATUS "librnp source found at ${RNPLIB_DEVEL_DIR} using it")
 		rnplib_set_inline_build_options()
 		add_subdirectory("${RNPLIB_DEVEL_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/librnp")


### PR DESCRIPTION
Supersedes #374, which fixed only the first symptom.

`prepare-toolchain-clang.sh` builds librnp with the openssl backend and installs it in the Android sysroot, but our own configure ignores it and builds librnp a **second** time, inline: `add_subdirectory()` is taken whenever `../supportlibs/librnp/CMakeLists.txt` exists, i.e. as soon as libretroshare is checked out inside the RetroShare super-project rather than standalone.

That inline build cannot work on Android, for a reason that has nothing to do with the crypto backend: librnp's `FindOpenSSLFeatures.cmake` compiles `findopensslfeatures` and **runs** it to enumerate the OpenSSL features. The binary it just built is an Android executable, which the build host cannot execute. Where binfmt/qemu picks it up — WSL, typically — it gets as far as the ELF interpreter and stops there:

```
CMake Error at .../supportlibs/librnp/cmake/Modules/FindOpenSSLFeatures.cmake:151 (message):
  Error getting supported OpenSSL hashes: 255

  qemu-aarch64: Could not open '/system/bin/linker64': No such file or directory
```

Note the path: that is the **super-project's** pinned librnp submodule, not the copy the toolchain script clones and patches, so none of the script's cross-compilation workarounds apply to it.

This prefers the pre-built library when `RS_ANDROID` is set, falling back to the previous behaviour when none is installed. Desktop builds are untouched (`RS_ANDROID` is OFF, the local librnp source is used exactly as today).

Why CI never saw it: the GitLab AAR jobs build from this repository standalone, so `../supportlibs/librnp` does not exist and `find_library(NAMES rnp)` already picked up the sysroot copy. The bug only shows up in a super-project checkout.

Verified by exercising the three paths of the edited block: desktop + librnp submodule present → inline, unchanged; Android + pre-built librnp → pre-built; Android + nothing installed → inline, as before.

Reported on IRC by defnax, building the AAR for rs-mobile under WSL.