### PR TITLE
Android: link libdl into rnp's OpenSSL feature probe

### DIFF
--- a/misc/Android/prepare-toolchain-clang.sh
+++ b/misc/Android/prepare-toolchain-clang.sh
@@ -878,6 +878,23 @@ endif(CMAKE_CROSSCOMPILING_EMULATOR)' \
 	sed -i 's|COMMAND "${FOF}" "${feature}"|COMMAND ${FOF} "${feature}"|' \
 		"${S_dir}/cmake/Modules/FindOpenSSLFeatures.cmake"
 
+	# The feature probe is linked statically, and OpenSSL 1.1.1 libcrypto.a
+	# pulls in dso_dlfcn.o which references dlopen/dlsym/dlclose/dlerror.
+	# CMake's FindOpenSSL does not put ${CMAKE_DL_LIBS} in the OpenSSL::Crypto
+	# interface here, so nothing provides them and the link dies with
+	#
+	#   ld.lld: error: undefined symbol: dlopen
+	#   >>> referenced by dso_dlfcn.c
+	#   >>>               dso_dlfcn.o:(dlfcn_load) in archive .../libcrypto.a
+	#
+	# The NDK ships a static libdl.a defining those symbols, so link it
+	# explicitly. It has to come after libcrypto.a for the static linker to
+	# pick it up, hence a linked library rather than CMAKE_EXE_LINKER_FLAGS,
+	# which CMake places before the objects.
+	sed -i \
+		's|(findopensslfeatures PRIVATE OpenSSL::Crypto)|(findopensslfeatures PRIVATE OpenSSL::Crypto dl)|' \
+		"${S_dir}/cmake/Modules/FindOpenSSLFeatures.cmake"
+
 	rm -rf "$B_dir"; mkdir "$B_dir"
 	pushd "$B_dir" || return $?
 	# CRYPTO_BACKEND use openssl on which we already depends instead of default

--- a/misc/Android/prepare-toolchain-clang.sh
+++ b/misc/Android/prepare-toolchain-clang.sh
@@ -888,9 +888,10 @@ endif(CMAKE_CROSSCOMPILING_EMULATOR)' \
 	#   >>>               dso_dlfcn.o:(dlfcn_load) in archive .../libcrypto.a
 	#
 	# The NDK ships a static libdl.a defining those symbols, so link it
-	# explicitly. It has to come after libcrypto.a for the static linker to
-	# pick it up, hence a linked library rather than CMAKE_EXE_LINKER_FLAGS,
-	# which CMake places before the objects.
+	# explicitly, as a linked library rather than CMAKE_EXE_LINKER_FLAGS so
+	# it is ordered after libcrypto.a for linkers that resolve archives in a
+	# single pass (lld does not care, GNU ld does).
+	# Submitted upstream as rnpgp/rnp#2473; drop this sed once it is in.
 	sed -i \
 		's|(findopensslfeatures PRIVATE OpenSSL::Crypto)|(findopensslfeatures PRIVATE OpenSSL::Crypto dl)|' \
 		"${S_dir}/cmake/Modules/FindOpenSSLFeatures.cmake"


### PR DESCRIPTION
`build_librnp` fails while rnp configures itself:

```
ld.lld: error: undefined symbol: dlopen
>>> referenced by dso_dlfcn.c
>>>               dso_dlfcn.o:(dlfcn_load) in archive .../sysroot/usr/lib/libcrypto.a
```
```
CMake Error at cmake/Modules/FindOpenSSLFeatures.cmake:149 (message):
  Error building findopensslfeatures
```

rnp compiles a small `findopensslfeatures` helper and runs it to enumerate the
OpenSSL features. When cross-compiling it links that helper statically, so it
does not need the Android dynamic linker:

```cmake
if(CMAKE_CROSSCOMPILING_EMULATOR)
  target_link_options(findopensslfeatures PRIVATE -static)
endif(CMAKE_CROSSCOMPILING_EMULATOR)
```

but OpenSSL 1.1.1's `libcrypto.a` pulls in `dso_dlfcn.o`, which references the
`dl*` API, and CMake's `FindOpenSSL` does not add `${CMAKE_DL_LIBS}` to the
`OpenSSL::Crypto` interface here. The link line ends up as

```
clang -O3 -DNDEBUG -static ...o -o findopensslfeatures  .../libcrypto.a -pthread
```

with nothing providing `dlopen`, `dlsym`, `dlclose` and `dlerror`.

The NDK does ship a static `libdl.a` defining those four for real, so it is
enough to link it. It is added as a linked library rather than through
`CMAKE_EXE_LINKER_FLAGS`, because CMake places that variable *before* the
objects, where a static linker has no undefined symbol to resolve yet and drops
the archive silently.

This is arguably rnp's bug — their `-static` path looks untested against a
static OpenSSL 1.1.1 — so the patch stays a `sed` next to the existing ones, and
should be dropped once rnp handles it.

### Verified

`build_librnp` completes and installs `librnp.a` in the sysroot, and the whole
AAR now builds: 42 MB, `jni/arm64-v8a/libretroshare.so` exporting `JNI_OnLoad`,
the four `org.retroshare.service` classes in `classes.jar`. Ubuntu 24.04, NDK
`29.0.14206865`, API level 24, `arm64-v8a`, on top of #373 and #375.
