### PR TITLE
Android: tell libtiff where libm is

### DIFF
--- a/misc/Android/prepare-toolchain-clang.sh
+++ b/misc/Android/prepare-toolchain-clang.sh
@@ -749,11 +749,21 @@ build_tiff()
 
 	pushd $B_dir
 	#TODO: build dependecies to support more formats
+	# tiff cmake/FindCMath.cmake looks for pow(3) first without any library
+	# then with whatever find_library(NAMES m) returned. On Android pow lives
+	# in libm, and libm is under the API level directory of the NDK sysroot,
+	# which andro_cmake does not put in CMAKE_LIBRARY_PATH, so find_library
+	# comes back empty, the second check links without -lm just like the first
+	# one and configure aborts with
+	#   Could NOT find CMath (missing: CMath_pow)
+	# Give it the library explicitly instead of widening the search path for
+	# every dependency.
 	andro_cmake \
 		-DBUILD_SHARED_LIBS=OFF \
 		-Dlibdeflate=OFF -Djbig=OFF -Dlzma=OFF -Dzstd=OFF -Dwebp=OFF \
 		-Djpeg12=OFF \
 		-Dcxx=OFF \
+		-DCMath_LIBRARY="${SYSROOT}/usr/lib/${compilerTriple}/${ANDROID_PLATFORM_VER}/libm.so" \
 		-B. -S../$S_dir    || return $?
 	make -j${HOST_NUM_CPU} || return $?
 	make install           || return $?


### PR DESCRIPTION
`build_tiff` fails at configure time, and takes `build_cimg` and `build_phash`
down with it:

```
-- Looking for pow
-- Looking for pow - not found
-- Looking for pow
-- Looking for pow - not found
CMake Error at FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find CMath (missing: CMath_pow)
Call Stack (most recent call first):
  cmake/FindCMath.cmake:51 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:156 (find_package)
```

tiff's `cmake/FindCMath.cmake` probes `pow(3)` twice — once with no extra
library, then again with whatever `find_library(NAMES m)` returned:

```cmake
check_symbol_exists(pow "math.h" CMath_HAVE_LIBC_POW)
find_library(CMath_LIBRARY NAMES m)

if(NOT CMath_HAVE_LIBC_POW)
    set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${CMath_LIBRARY})
    check_symbol_exists(pow "math.h" CMath_HAVE_LIBM_POW)
```

On Android `pow` is in libm, and the NDK keeps `libm.so` under the API level
directory of the sysroot — `sysroot/usr/lib/<triple>/<api>/` — which
`andro_cmake` does not add to `CMAKE_LIBRARY_PATH`; it sets it to `${PREFIX}/lib`
only. So `find_library` returns NOTFOUND, `CMAKE_REQUIRED_LIBRARIES` gains
nothing, the second probe links exactly like the first one, and both fail with
`undefined symbol: pow`. Note the two identical `Looking for pow - not found`
lines in the output above: that pair is the signature of this bug.

Passing `CMath_LIBRARY` explicitly fixes it. The alternative — adding the API
level directory to the library search path in `andro_cmake` — would change how
the ten dependencies that already build resolve their libraries, for one
consumer.

### Verified

`build_tiff`, `build_cimg` and `build_phash` all return 0, and the whole AAR now
builds: 42 MB, `jni/arm64-v8a/libretroshare.so` exporting `JNI_OnLoad`, the four
`org.retroshare.service` classes in `classes.jar`. Ubuntu 24.04, NDK
`29.0.14206865`, API level 24, `arm64-v8a`.
