### PR TITLE
Distant chat: closing a conversation left its contact behind, and always reported success

### DIFF
--- a/src/chat/distantchat.cc
+++ b/src/chat/distantchat.cc
@@ -327,11 +327,40 @@ bool DistantChatService::getDistantChatStatus(const DistantChatPeerId& tunnel_id
 
 bool DistantChatService::closeDistantChatConnexion(const DistantChatPeerId &tunnel_id)
 {
-    mGxsTunnels->closeExistingTunnel(RsGxsTunnelId(tunnel_id), DISTANT_CHAT_GXS_TUNNEL_SERVICE_ID) ;
-    
-    // also remove contact. Or do we wait for the notification?
-    
-    return true ;
+    // The contact has to go with the tunnel: the entry in mDistantChatContacts
+    // is the core's record of an open conversation -- handleOutgoingItem()
+    // accepts outgoing items for as long as it is there -- and
+    // markDistantChatAsClosed(), the remote-close path, removes it. Nothing
+    // removed it when we closed the conversation ourselves.
+
+    bool tunnel_closed = mGxsTunnels->closeExistingTunnel(
+                RsGxsTunnelId(tunnel_id), DISTANT_CHAT_GXS_TUNNEL_SERVICE_ID );
+
+    bool contact_removed = false;
+    {
+        RS_STACK_MUTEX(mDistantChatMtx) ;
+
+        auto it = mDistantChatContacts.find(tunnel_id) ;
+
+        if(it != mDistantChatContacts.end())
+        {
+            mDistantChatContacts.erase(it) ;
+            contact_removed = true ;
+        }
+    }
+
+    // The two can disagree in one direction only: p3GxsTunnelService prunes
+    // remotely-closed tunnels on its own after 20s, so the tunnel may already
+    // be gone while the contact is still registered. The converse -- a closed
+    // tunnel with no contact -- is an anomaly.
+    if(tunnel_closed && !contact_removed)
+        std::cerr << "(EE) closeDistantChatConnexion(): tunnel " << tunnel_id << " was closed, but no distant chat contact was registered for it." << std::endl;
+
+    // Answering true whatever happened made every client -- the chat window,
+    // the web UI, any JSON API caller -- report a conversation as closed when
+    // nothing had been closed at all, the tunnel having died on its own before.
+
+    return tunnel_closed || contact_removed ;
 }
 
 uint32_t DistantChatService::getDistantChatPermissionFlags()


### PR DESCRIPTION
`DistantChatService::closeDistantChatConnexion()` closes the GXS tunnel and stops there, on a comment wondering whether the contact should go with it:

```cpp
mGxsTunnels->closeExistingTunnel(RsGxsTunnelId(tunnel_id), DISTANT_CHAT_GXS_TUNNEL_SERVICE_ID) ;

// also remove contact. Or do we wait for the notification?

return true ;
```

It should: the entry in `mDistantChatContacts` is the core's record of an open conversation — `handleOutgoingItem()` accepts outgoing items for as long as it is there — and `markDistantChatAsClosed()`, the remote-close path, removes it. Nothing removed it when we closed the conversation ourselves. Found from the web UI, where "Leave Chat" left a conversation that kept coming back.

The return value was the constant `true`, so every caller — the chat window, the web UI, any JSON API client — was told the conversation had been closed even when there was nothing to close. That is not a rare case: `closeExistingTunnel()` answers false and logs

```
(EE) Cannot close distant tunnel connection. No connection openned for tunnel id 7dfee99a...
```

once p3GxsTunnelService has pruned a remotely-closed tunnel, which it does on its own ~20s after the close arrives — the normal state of a conversation whose peer has left. The function now answers whether anything was actually released — tunnel, contact, or both — and logs an (EE) error in the one inconsistent case, a closed tunnel with no registered contact.

Built on Linux against current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
