### PR TITLE
I2P/SAM3: move the session restart delay off the stop path, it delayed shutdown by 10 s

### DIFF
--- a/src/services/autoproxy/p3i2psam3.cpp
+++ b/src/services/autoproxy/p3i2psam3.cpp
@@ -29,6 +29,14 @@ static const std::string kConfigKeyBOBAddr     = "BOB_ADDR";
 
 static constexpr bool   kDefaultSAM3Enable = false;
 
+/* At least i2pd doesn't like to instantaniously stop and (re)start a session, so
+ * a new session is never created less than this long after the previous one was
+ * closed. The wait happens in startSession(), where it is actually needed, and
+ * not in stopSession(): a stop is not always followed by a start (RS shutdown,
+ * "stop" button in the settings) and waiting there held back the whole
+ * application exit by 10 seconds. */
+static constexpr auto kSessionRestartDelay = std::chrono::seconds(10);
+
 RS_SET_CONTEXT_DEBUG_LEVEL(2)
 
 static void inline doSleep(std::chrono::duration<long, std::ratio<1,1000>> timeToSleepMS) {
@@ -36,7 +44,9 @@ static void inline doSleep(std::chrono::duration<long, std::ratio<1,1000>> timeT
 }
 
 p3I2pSam3::p3I2pSam3(p3PeerMgr *peerMgr) :
-    mConfigLoaded(false), mPeerMgr(peerMgr), mPending(), mLock("p3i2p-sam3")
+    mConfigLoaded(false), mPeerMgr(peerMgr), mPending(),
+    mLastSessionClosed(std::chrono::steady_clock::time_point::min()),
+    mLock("p3i2p-sam3")
 #ifdef RS_USE_I2P_SAM3_LIBSAM3
   , mLockSam3Access("p3i2p-sam3-access")
 #endif
@@ -498,6 +508,19 @@ bool p3I2pSam3::startSession()
 		stopSession();
 	}
 
+	// Give i2pd time to let go of the previous session. No lock may be held here.
+	std::chrono::steady_clock::time_point sessionReady;
+	{
+		RS_STACK_MUTEX(mLock);
+		sessionReady = mLastSessionClosed + kSessionRestartDelay;
+	}
+	const auto now = std::chrono::steady_clock::now();
+	if (now < sessionReady) {
+		const auto wait = std::chrono::duration_cast<std::chrono::milliseconds>(sessionReady - now);
+		RS_DBG("waiting ", wait.count(), " ms before creating a new SAM session");
+		doSleep(wait);
+	}
+
 	auto session = (Sam3Session*)rs_malloc(sizeof (Sam3Session));
 
 	// add nick
@@ -592,12 +615,10 @@ void p3I2pSam3::stopSession()
 
 		mSetting.session = nullptr;
 		mState = samStatus::samState::offline;
-	}
 
-	// At least i2pd doesn't like to instantaniously stop and (re)start a session, wait here just a little bit.
-	// Not ideal but does the trick.
-	// (This happens when using the "restart" button in the settings.)
-	doSleep(std::chrono::seconds(10));
+		// startSession() waits out kSessionRestartDelay counted from here
+		mLastSessionClosed = std::chrono::steady_clock::now();
+	}
 }
 
 void p3I2pSam3::stopForwarding()

--- a/src/services/autoproxy/p3i2psam3.h
+++ b/src/services/autoproxy/p3i2psam3.h
@@ -1,6 +1,7 @@
 #ifndef P3I2PSAM3_H
 #define P3I2PSAM3_H
 
+#include <chrono>
 #include <queue>
 #include <list>
 
@@ -101,6 +102,10 @@ private:
 
 	// used to keep track of connections, libsam3 does it internally but it can be unreliable since pointers are shared
 	std::list<Sam3Connection *> mValidConnections, mInvalidConnections;
+
+	// Point in time at which the last SAM session was closed. startSession() uses
+	// it to honour kSessionRestartDelay. Guarded by mLock.
+	std::chrono::steady_clock::time_point mLastSessionClosed;
 
 	// mutex
 	RsMutex mLock;


### PR DESCRIPTION
`p3I2pSam3::stopSession()` ends with an unconditional ten second sleep:

```cpp
// At least i2pd doesn't like to instantaniously stop and (re)start a session, wait here just a little bit.
// Not ideal but does the trick.
// (This happens when using the "restart" button in the settings.)
doSleep(std::chrono::seconds(10));
```

The reason behind it is real: `ServerPage::restartSam()` posts a `stop` ticket immediately followed by a `start` ticket on the same service-thread queue, and `startSession()` itself calls `stopSession()` when a session is already open. Without the delay, i2pd is asked to recreate a session it has just closed.

But a stop is not always followed by a start. `RsServer::rsGlobalShutDown()` calls `rsAutoProxyMonitor::stopAllRSShutdown()`, which posts that same `stop` ticket and then waits — up to 15 s, polling once per second — for the service to acknowledge it. The sleep therefore holds the whole application exit back by ten seconds, every time, on every node with SAM3 enabled:

```
D  rsAutoProxyMonitor::stopAllRSShutdown() waiting for auto proxy service(s) to shut down 0/15 (remaining: 1)
D  rsAutoProxyMonitor::stopAllRSShutdown() waiting for auto proxy service(s) to shut down 1/15 (remaining: 1)
...
D  rsAutoProxyMonitor::stopAllRSShutdown() waiting for auto proxy service(s) to shut down 10/15 (remaining: 0)
```

That is 10.0 s out of a 21.8 s shutdown, spent sleeping. The "stop" button in the settings pays it too, just as uselessly.

This keeps the delay but moves it to where it is actually needed. `stopSession()` records when the session was closed; `startSession()` waits out whatever is left of the ten seconds before creating a new one. The guarantee i2pd relies on is unchanged — a session is still never created less than ten seconds after the previous one was closed, whichever path led there — but a stop that is not followed by a start now returns immediately.

Two details worth noting:

- the wait sits *after* the `stopSession()` that `startSession()` may perform itself, so the restart path is covered as well as the two-ticket one;
- `mLastSessionClosed` starts at `time_point::min()` and the comparison is done on a deadline rather than a subtraction, so the first session of the process never waits and there is no overflow.

Measured on the same node after the change: the monitor logs a single `0/15 (remaining: 0)` line and the shutdown went from 21.8 s to 8.6 s.

Two files, no API change. Built with CMake and run for a couple of hours on Linux/Qt5 as part of a local integration branch — that is where the numbers come from — but not built standalone against master.
