### PR TITLE
Distant chat: tell every client when a conversation is closed locally

### DIFF
--- a/src/chat/distantchat.cc
+++ b/src/chat/distantchat.cc
@@ -360,7 +360,25 @@ bool DistantChatService::closeDistantChatConnexion(const DistantChatPeerId &tunn
     // the web UI, any JSON API caller -- report a conversation as closed when
     // nothing had been closed at all, the tunnel having died on its own before.
 
-    return tunnel_closed || contact_removed ;
+    bool closed = tunnel_closed || contact_removed ;
+
+    // The client that asked for the close knows about it; the others do not,
+    // and a conversation closed from the web UI stayed open in the desktop
+    // chat window. Polling cannot fix that: once the tunnel is gone,
+    // getDistantChatStatus() answers the same false for a conversation the
+    // peer closed (where the window should stay open) and for one we closed
+    // from another client (where it should go). Only an explicit event tells
+    // them apart, so post it here -- and every client of this core drops the
+    // conversation at the same time.
+    if(closed && rsEvents)
+    {
+        auto ev = std::make_shared<RsDistantChatEvent>();
+        ev->mEventCode = RsDistantChatEventCode::TUNNEL_STATUS_LOCALLY_CLOSED;
+        ev->mId = tunnel_id;
+        rsEvents->postEvent(ev);
+    }
+
+    return closed ;
 }
 
 uint32_t DistantChatService::getDistantChatPermissionFlags()

--- a/src/chat/distantchat.cc
+++ b/src/chat/distantchat.cc
@@ -327,11 +327,40 @@ bool DistantChatService::getDistantChatStatus(const DistantChatPeerId& tunnel_id
 
 bool DistantChatService::closeDistantChatConnexion(const DistantChatPeerId &tunnel_id)
 {
-    mGxsTunnels->closeExistingTunnel(RsGxsTunnelId(tunnel_id), DISTANT_CHAT_GXS_TUNNEL_SERVICE_ID) ;
-    
-    // also remove contact. Or do we wait for the notification?
-    
-    return true ;
+    // The contact has to go with the tunnel: the entry in mDistantChatContacts
+    // is the core's record of an open conversation -- handleOutgoingItem()
+    // accepts outgoing items for as long as it is there -- and
+    // markDistantChatAsClosed(), the remote-close path, removes it. Nothing
+    // removed it when we closed the conversation ourselves.
+
+    bool tunnel_closed = mGxsTunnels->closeExistingTunnel(
+                RsGxsTunnelId(tunnel_id), DISTANT_CHAT_GXS_TUNNEL_SERVICE_ID );
+
+    bool contact_removed = false;
+    {
+        RS_STACK_MUTEX(mDistantChatMtx) ;
+
+        auto it = mDistantChatContacts.find(tunnel_id) ;
+
+        if(it != mDistantChatContacts.end())
+        {
+            mDistantChatContacts.erase(it) ;
+            contact_removed = true ;
+        }
+    }
+
+    // The two can disagree in one direction only: p3GxsTunnelService prunes
+    // remotely-closed tunnels on its own after 20s, so the tunnel may already
+    // be gone while the contact is still registered. The converse -- a closed
+    // tunnel with no contact -- is an anomaly.
+    if(tunnel_closed && !contact_removed)
+        std::cerr << "(EE) closeDistantChatConnexion(): tunnel " << tunnel_id << " was closed, but no distant chat contact was registered for it." << std::endl;
+
+    // Answering true whatever happened made every client -- the chat window,
+    // the web UI, any JSON API caller -- report a conversation as closed when
+    // nothing had been closed at all, the tunnel having died on its own before.
+
+    return tunnel_closed || contact_removed ;
 }
 
 uint32_t DistantChatService::getDistantChatPermissionFlags()

--- a/src/retroshare/rschats.h
+++ b/src/retroshare/rschats.h
@@ -249,6 +249,7 @@ enum class RsDistantChatEventCode: uint8_t
     TUNNEL_STATUS_TUNNEL_DN               = 0x02,
     TUNNEL_STATUS_REMOTELY_CLOSED         = 0x03,
     TUNNEL_STATUS_CONNECTION_REFUSED      = 0x04,
+    TUNNEL_STATUS_LOCALLY_CLOSED          = 0x05, // we closed it ourselves (closeDistantChatConnexion), from any client of this core
 };
 
 struct RsChatLobbyEvent : RsEvent // This event handles events internal to the distributed chat system


### PR DESCRIPTION
Stacked on #378 (`fix/distant-chat-close-keeps-contact`): the first commit here is that PR's, this one adds the second. Merge #378 first and this reduces to one commit.

`closeDistantChatConnexion()` posted no event. The client that called it knew; the others did not: a conversation opened and then left from the web UI stayed open — green LED and all — in the desktop window the core had popped for it, and closing that window then offered to end a conversation that no longer existed. Polling cannot fix that: once the tunnel is gone, `getDistantChatStatus()` answers the same false for a conversation the peer closed (where the window should stay open) and for one closed from another client (where it should go); only an explicit event tells the two apart.

This adds `RsDistantChatEventCode::TUNNEL_STATUS_LOCALLY_CLOSED` (0x05) and posts it from `closeDistantChatConnexion()` whenever something was actually closed, with the tunnel id, so every client of this core — desktop GUI, web UI, JSON API users — drops the conversation at the same time. The remote close path is untouched: `markDistantChatAsClosed()` stays as it was, and `REMOTELY_CLOSED` keeps coming from `notifyTunnelStatus()`.

GUI counterpart: RetroShare/RetroShare#3297 (closes the popup on this event).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
