### PR TITLE
build(cmake): fix target name for RS_JEREMY_RIFKIN_CPPTRACE definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -978,7 +978,7 @@ if(RS_CPPTRACE_STACKTRACE)
     FetchContent_MakeAvailable(cpptrace)
     target_link_libraries(${PROJECT_NAME} PRIVATE cpptrace::cpptrace)
     target_compile_definitions(
-        ${LIBRARY_NAME} PRIVATE RS_JEREMY_RIFKIN_CPPTRACE )
+        ${PROJECT_NAME} PRIVATE RS_JEREMY_RIFKIN_CPPTRACE )
 endif(RS_CPPTRACE_STACKTRACE)
 
 if(RS_USE_I2P_SAM3)


### PR DESCRIPTION
When building with `-DRS_CPPTRACE_STACKTRACE=ON`, `target_compile_definitions()` referenced `${LIBRARY_NAME}`, which is undefined in this scope.

As a result:
- CMake evaluated the target name to empty, so `-DRS_JEREMY_RIFKIN_CPPTRACE` was never passed to the compiler.
- `rsstacktrace.cc` silently ignored `cpptrace` (even though the library was fetched and linked).
- On **Windows** and **macOS**, stack traces remained disabled (*"Not implemented yet for this platform"*), while Linux fell back to the basic glibc implementation without file/line resolution.

Fix by using `${PROJECT_NAME}` (matching `target_link_libraries` on the previous line).